### PR TITLE
Run clang format before every commit

### DIFF
--- a/.git_hooks/pre-commit
+++ b/.git_hooks/pre-commit
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Check for errors
+set -e
+
+# Make sure that clang-format exists
+if ! hash clang-format 2>/dev/null
+then
+    echo "'clang-format' was not found in PATH"
+    exit 1
+fi
+
+# Create patch file
+now=`date +"%Y-%m-%d-%H:%M:%S"`
+patch_filename="/tmp/${now}.patch"
+git clang-format -v --diff > ${patch_filename}
+
+# Show recommendations for user
+if grep -q "+++" "${patch_filename}";
+then
+    echo "Your changes do not conform with project's rules."
+    echo "Run: git apply ${patch_filename}"
+    exit 1
+else
+    echo "Your changes are in line with project's rules."
+fi

--- a/README.md
+++ b/README.md
@@ -154,3 +154,10 @@ execute one of the following make commands. This step is not necessary in case t
 
 For any further information, please do not hesitate to
 send an email at nkallima (at) ics.forth.gr. Feedback is always valuable.
+
+
+# Contribution
+
+If you wish to contribute to the project:
+- Install `clang-format` package (version >= 10)
+- After cloning the repository you need to run `git config --local core.hooksPath .git_hooks` to enable recommended code style checkes (placed in .clang_format file) during git commit. If the tool discovers incosistencies, it will create a patch file. Please follow the instructions to apply the patch before opening a pull request.


### PR DESCRIPTION
Added pre-commit hook for running the clang format on changed files and modified documentation