### PR TITLE
Switched C standard from `gnu89` to `C11`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 v3.4.0
 ------
+- Switched C standard from `gnu89` to `C11` for improved compatibility, modern features, and better code maintainability.
 - Setting `-flto=auto` in makefiles for better compiling performance
 - Modified the `check-build` and `validate` workflow triggers from 'main' branch only to all branches except `gh-pages` branch.
 

--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,16 @@ codecov:
 	make $(ARCH) D_ARGS="-DDEBUG -ftest-coverage -fprofile-arcs --coverage -O0"
 
 x86_64:
-	make -f Makefile.generic -j $(NPROC) COMPILER=$(CC) LDLIBS='$(LIBS)' CFLAGS='-Wall -std=gnu89 -Ofast -fPIC -flto=auto -ftree-vectorize -finline-functions -march=native -mtune=native'
+	make -f Makefile.generic -j $(NPROC) COMPILER=$(CC) LDLIBS='$(LIBS)' CFLAGS='-Wall -std=c11 -Ofast -fPIC -flto=auto -ftree-vectorize -finline-functions -march=native -mtune=native -D_XOPEN_SOURCE=700'
 
 icx:
-	make -f Makefile.generic -j $(NPROC) COMPILER=icx LDLIBS='$(LIBS)' CFLAGS='-Wall -std=gnu89 -O3 -fPIC -ftree-vectorize -finline-functions -march=native -mtune=native'
+	make -f Makefile.generic -j $(NPROC) COMPILER=icx LDLIBS='$(LIBS)' CFLAGS='-Wall -std=c11 -O3 -fPIC -ftree-vectorize -finline-functions -march=native -mtune=native -D_XOPEN_SOURCE=700'
 
 clang:
-	make -f Makefile.generic -j $(NPROC) COMPILER=clang AR=$(CLANG_AR) LDLIBS='$(LIBS)' CFLAGS='-Wall -std=gnu89 -Ofast -fPIC -ftree-vectorize -finline-functions -march=native -mtune=native'
+	make -f Makefile.generic -j $(NPROC) COMPILER=clang AR=$(CLANG_AR) LDLIBS='$(LIBS)' CFLAGS='-Wall -std=c11 -Ofast -fPIC -ftree-vectorize -finline-functions -march=native -mtune=native -D_XOPEN_SOURCE=700'
 
 unknown:
-	make -f Makefile.generic -j $(NPROC) COMPILER=$(CC) LDLIBS='$(LIBS)'  CFLAGS='-std=gnu89 -Ofast -fPIC -flto=auto'
+	make -f Makefile.generic -j $(NPROC) COMPILER=$(CC) LDLIBS='$(LIBS)'  CFLAGS='-std=c11 -Ofast -fPIC -flto=auto -D_XOPEN_SOURCE=700'
 
 clean:
 	make -f Makefile.generic clean

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ volatile int64_t object CACHE_ALIGN;
 int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     long i, id;
 
     id = synchGetThreadId();

--- a/benchmarks/activesetbench.c
+++ b/benchmarks/activesetbench.c
@@ -17,7 +17,7 @@ volatile ToggleVector active_set CACHE_ALIGN;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     long i, rnum, mybank;
     volatile long j;
     int id = synchGetThreadId();

--- a/benchmarks/ccheapbench.c
+++ b/benchmarks/ccheapbench.c
@@ -17,7 +17,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void* Arg) {
+static void *Execute(void* Arg) {
     CCHeapThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/ccqueuebench.c
+++ b/benchmarks/ccqueuebench.c
@@ -18,7 +18,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     CCQueueThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/ccstackbench.c
+++ b/benchmarks/ccstackbench.c
@@ -17,7 +17,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     CCStackThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/ccsynchbench.c
+++ b/benchmarks/ccsynchbench.c
@@ -19,7 +19,7 @@ int64_t d1, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     CCSynchThreadState *th_state;
     long i, rnum;
     volatile long j;

--- a/benchmarks/clhbench.c
+++ b/benchmarks/clhbench.c
@@ -22,7 +22,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline void apply_op(RetVal (*sfunc)(void *, ArgVal, int), void *state, ArgVal arg, int pid) {
+void apply_op(RetVal (*sfunc)(void *, ArgVal, int), void *state, ArgVal arg, int pid) {
     CLHLock(object_lock, pid);
     sfunc(state, arg, pid);
 #ifdef DEBUG
@@ -31,7 +31,7 @@ inline void apply_op(RetVal (*sfunc)(void *, ArgVal, int), void *state, ArgVal a
     CLHUnlock(object_lock, pid);
 }
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     long i, rnum;
     volatile long j;
     int id = synchGetThreadId();

--- a/benchmarks/clhhashbench.c
+++ b/benchmarks/clhhashbench.c
@@ -25,7 +25,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     int64_t key, value;
     CLHHashThreadState *th_state;
     long i, rnum;

--- a/benchmarks/clhqueuebench.c
+++ b/benchmarks/clhqueuebench.c
@@ -31,7 +31,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-__thread SynchPoolStruct pool_node;
+_Thread_local SynchPoolStruct pool_node;
 
 static void enqueue(Object arg, int pid) {
     Node *n = synchAllocObj(&pool_node);

--- a/benchmarks/clhqueuebench.c
+++ b/benchmarks/clhqueuebench.c
@@ -33,7 +33,7 @@ SynchBenchArgs bench_args CACHE_ALIGN;
 
 __thread SynchPoolStruct pool_node;
 
-inline static void enqueue(Object arg, int pid) {
+static void enqueue(Object arg, int pid) {
     Node *n = synchAllocObj(&pool_node);
 
     n->val = (Object)arg;
@@ -48,7 +48,7 @@ inline static void enqueue(Object arg, int pid) {
     CLHUnlock(ltail, pid);
 }
 
-inline static Object dequeue(int pid) {
+static Object dequeue(int pid) {
     Object result;
     Node *node = NULL;
 
@@ -75,7 +75,7 @@ inline static Object dequeue(int pid) {
     return result;
 }
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     long i;
     long rnum;
     int id = synchGetThreadId();

--- a/benchmarks/clhstackbench.c
+++ b/benchmarks/clhstackbench.c
@@ -26,7 +26,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-__thread SynchPoolStruct pool_node;
+_Thread_local SynchPoolStruct pool_node;
 
 static void push(Object arg, int pid) {
     volatile Node *n = synchAllocObj(&pool_node);

--- a/benchmarks/clhstackbench.c
+++ b/benchmarks/clhstackbench.c
@@ -28,7 +28,7 @@ SynchBenchArgs bench_args CACHE_ALIGN;
 
 __thread SynchPoolStruct pool_node;
 
-inline static void push(Object arg, int pid) {
+static void push(Object arg, int pid) {
     volatile Node *n = synchAllocObj(&pool_node);
     n->val = (Object)arg;
     CLHLock(lock, pid);  // Critical section
@@ -41,7 +41,7 @@ inline static void push(Object arg, int pid) {
     CLHUnlock(lock, pid);
 }
 
-inline static Object pop(int pid) {
+static Object pop(int pid) {
     Object result;
     Node *n = NULL;
 
@@ -63,7 +63,7 @@ inline static Object pop(int pid) {
     return result;
 }
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     long i;
     long rnum;
     int id = synchGetThreadId();

--- a/benchmarks/dsmhashbench.c
+++ b/benchmarks/dsmhashbench.c
@@ -25,7 +25,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     int64_t key, value;
     DSMHashThreadState *th_state;
     long i, rnum;

--- a/benchmarks/dsmheapbench.c
+++ b/benchmarks/dsmheapbench.c
@@ -17,7 +17,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void* Arg) {
+static void *Execute(void* Arg) {
     DSMHeapThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/dsmqueuebench.c
+++ b/benchmarks/dsmqueuebench.c
@@ -18,7 +18,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     DSMQueueThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/dsmstackbench.c
+++ b/benchmarks/dsmstackbench.c
@@ -17,7 +17,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     DSMStackThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/dsmsynchbench.c
+++ b/benchmarks/dsmsynchbench.c
@@ -19,7 +19,7 @@ int64_t d1, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     DSMSynchThreadState *th_state;
     long i, rnum;
     volatile long j;

--- a/benchmarks/fadbench.c
+++ b/benchmarks/fadbench.c
@@ -16,7 +16,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     long i, rnum;
     volatile int j;
     int id = synchGetThreadId();

--- a/benchmarks/fcbench.c
+++ b/benchmarks/fcbench.c
@@ -19,7 +19,7 @@ int64_t d1, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     FCThreadState *th_state;
     long i, rnum;
     volatile long j;

--- a/benchmarks/fcheapbench.c
+++ b/benchmarks/fcheapbench.c
@@ -17,7 +17,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void* Arg) {
+static void *Execute(void* Arg) {
     FCHeapThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/fcqueuebench.c
+++ b/benchmarks/fcqueuebench.c
@@ -18,7 +18,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     FCQueueThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/fcstackbench.c
+++ b/benchmarks/fcstackbench.c
@@ -17,7 +17,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     FCStackThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/hheapbench.c
+++ b/benchmarks/hheapbench.c
@@ -17,7 +17,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void* Arg) {
+static void *Execute(void* Arg) {
     HSynchHeapThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/hqueuebench.c
+++ b/benchmarks/hqueuebench.c
@@ -18,7 +18,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     HQueueThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/hstackbench.c
+++ b/benchmarks/hstackbench.c
@@ -17,7 +17,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     HStackThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/hsynchbench.c
+++ b/benchmarks/hsynchbench.c
@@ -19,7 +19,7 @@ int64_t d1, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     HSynchThreadState th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/lcrqbench.c
+++ b/benchmarks/lcrqbench.c
@@ -15,7 +15,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     LCRQThreadState thread_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/lfstackbench.c
+++ b/benchmarks/lfstackbench.c
@@ -12,7 +12,7 @@ int MIN_BAK, MAX_BAK;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     LFStackThreadState *th_state;
     long i;
     int id = synchGetThreadId();

--- a/benchmarks/lfuobjectbench.c
+++ b/benchmarks/lfuobjectbench.c
@@ -20,7 +20,7 @@ int MIN_BAK, MAX_BAK;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     LFUObjectThreadState *th_state;
     long i, rnum;
     volatile long j;

--- a/benchmarks/mcsbench.c
+++ b/benchmarks/mcsbench.c
@@ -23,7 +23,7 @@ SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
 
-inline void apply_op(RetVal (*sfunc)(void *, ArgVal, int), void *state, ArgVal arg, MCSThreadState *thread_state, int pid) {
+void apply_op(RetVal (*sfunc)(void *, ArgVal, int), void *state, ArgVal arg, MCSThreadState *thread_state, int pid) {
     MCSLock(object_lock, thread_state, pid);
     sfunc(state, arg, pid);
 #ifdef DEBUG
@@ -32,7 +32,7 @@ inline void apply_op(RetVal (*sfunc)(void *, ArgVal, int), void *state, ArgVal a
     MCSUnlock(object_lock, thread_state, pid);
 }
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     long i, rnum;
     volatile long j;
     int id = synchGetThreadId();

--- a/benchmarks/msqueuebench.c
+++ b/benchmarks/msqueuebench.c
@@ -19,7 +19,7 @@ int MIN_BAK, MAX_BAK;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     MSQueueThreadState *th_state;
     long i;
     int id = synchGetThreadId();

--- a/benchmarks/oscibench.c
+++ b/benchmarks/oscibench.c
@@ -19,7 +19,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     OsciThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/osciqueuebench.c
+++ b/benchmarks/osciqueuebench.c
@@ -17,7 +17,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     OsciQueueThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/oscistackbench.c
+++ b/benchmarks/oscistackbench.c
@@ -17,7 +17,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     OsciStackThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/oyamabench.c
+++ b/benchmarks/oyamabench.c
@@ -19,9 +19,9 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static RetVal fetchAndMultiply(ArgVal arg, int pid);
+static RetVal fetchAndMultiply(ArgVal arg, int pid);
 
-inline static RetVal fetchAndMultiply(ArgVal arg, int pid) {
+static RetVal fetchAndMultiply(ArgVal arg, int pid) {
     Object old_val;
 
     old_val = object;
@@ -29,7 +29,7 @@ inline static RetVal fetchAndMultiply(ArgVal arg, int pid) {
     return old_val;
 }
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     OyamaThreadState *th_state;
     long i, rnum;
     volatile int j;

--- a/benchmarks/pthreadsbench.c
+++ b/benchmarks/pthreadsbench.c
@@ -18,7 +18,7 @@ int64_t d1 CACHE_ALIGN, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     long i, rnum;
     volatile int j;
     int id = synchGetThreadId();

--- a/benchmarks/simbench.c
+++ b/benchmarks/simbench.c
@@ -16,7 +16,7 @@ SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 int MAX_BACK CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     SimThreadState th_state;
     long i, rnum;
     int id = synchGetThreadId();

--- a/benchmarks/simstackbench.c
+++ b/benchmarks/simstackbench.c
@@ -16,7 +16,7 @@ int64_t d1, d2;
 SynchBarrier bar CACHE_ALIGN;
 SynchBenchArgs bench_args CACHE_ALIGN;
 
-inline static void *Execute(void *Arg) {
+static void *Execute(void *Arg) {
     SimStackThreadState *th_state;
     long i = 0;
     int id = synchGetThreadId();

--- a/libconcurrent/concurrent/ccqueue.c
+++ b/libconcurrent/concurrent/ccqueue.c
@@ -1,8 +1,8 @@
 #include <ccqueue.h>
 #include <pool.h>
 
-inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
-inline static RetVal serialDequeue(void *state, ArgVal arg, int pid);
+static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
+static RetVal serialDequeue(void *state, ArgVal arg, int pid);
 
 static __thread SynchPoolStruct pool_node CACHE_ALIGN;
 
@@ -21,7 +21,7 @@ void CCQueueThreadStateInit(CCQueueStruct *object_struct, CCQueueThreadState *lo
     synchInitPool(&pool_node, sizeof(Node));
 }
 
-inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
+static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
     CCQueueStruct *st = (CCQueueStruct *)state;
     Node *node;
 
@@ -34,7 +34,7 @@ inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
     return ENQUEUE_SUCCESS;
 }
 
-inline static RetVal serialDequeue(void *state, ArgVal arg, int pid) {
+static RetVal serialDequeue(void *state, ArgVal arg, int pid) {
     CCQueueStruct *st = (CCQueueStruct *)state;
     volatile Node *node, *prev;
 

--- a/libconcurrent/concurrent/ccqueue.c
+++ b/libconcurrent/concurrent/ccqueue.c
@@ -4,7 +4,7 @@
 static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
 static RetVal serialDequeue(void *state, ArgVal arg, int pid);
 
-static __thread SynchPoolStruct pool_node CACHE_ALIGN;
+static _Thread_local SynchPoolStruct pool_node CACHE_ALIGN;
 
 void CCQueueStructInit(CCQueueStruct *queue_object_struct, uint32_t nthreads) {
     CCSynchStructInit(&queue_object_struct->enqueue_struct, nthreads);

--- a/libconcurrent/concurrent/ccstack.c
+++ b/libconcurrent/concurrent/ccstack.c
@@ -1,7 +1,7 @@
 #include <ccstack.h>
 #include <pool.h>
 
-inline static RetVal serialPushPop(void *state, ArgVal arg, int pid);
+static RetVal serialPushPop(void *state, ArgVal arg, int pid);
 
 static const int POP_OP = INT_MIN;
 static __thread SynchPoolStruct pool_node CACHE_ALIGN;
@@ -17,7 +17,7 @@ void CCStackThreadStateInit(CCStackStruct *object_struct, CCStackThreadState *lo
     synchInitPool(&pool_node, sizeof(Node));
 }
 
-inline static RetVal serialPushPop(void *state, ArgVal arg, int pid) {
+static RetVal serialPushPop(void *state, ArgVal arg, int pid) {
     if (arg == POP_OP) {
         volatile CCStackStruct *st = (CCStackStruct *)state;
         volatile Node *node = st->top;

--- a/libconcurrent/concurrent/ccstack.c
+++ b/libconcurrent/concurrent/ccstack.c
@@ -4,7 +4,7 @@
 static RetVal serialPushPop(void *state, ArgVal arg, int pid);
 
 static const int POP_OP = INT_MIN;
-static __thread SynchPoolStruct pool_node CACHE_ALIGN;
+static _Thread_local SynchPoolStruct pool_node CACHE_ALIGN;
 
 void CCStackInit(CCStackStruct *stack_object_struct, uint32_t nthreads) {
     CCSynchStructInit(&stack_object_struct->object_struct, nthreads);

--- a/libconcurrent/concurrent/clhhash.c
+++ b/libconcurrent/concurrent/clhhash.c
@@ -2,12 +2,12 @@
 #include <stdbool.h>
 #include <limits.h>
 
-static inline int64_t hash_func(CLHHash *hash, int64_t key);
-static inline RetVal serialOperations(void *h, ArgVal dummy_arg, int pid);
+static int64_t hash_func(CLHHash *hash, int64_t key);
+static RetVal serialOperations(void *h, ArgVal dummy_arg, int pid);
 
 static const int HT_INSERT = 0, HT_DELETE = 1, HT_SEARCH = 2;
 
-inline void CLHHashStructInit(CLHHash *hash, int num_cells, int nthreads) {
+void CLHHashStructInit(CLHHash *hash, int num_cells, int nthreads) {
     int i;
 
     hash->size = num_cells;
@@ -20,15 +20,15 @@ inline void CLHHashStructInit(CLHHash *hash, int num_cells, int nthreads) {
     }
 }
 
-inline void CLHHashThreadStateInit(CLHHash *hash, CLHHashThreadState *th_state, int num_cells, int pid) {
+void CLHHashThreadStateInit(CLHHash *hash, CLHHashThreadState *th_state, int num_cells, int pid) {
     synchInitPool(&th_state->pool, sizeof(HashNode));
 }
 
-static inline int64_t hash_func(CLHHash *hash, int64_t key) {
+static int64_t hash_func(CLHHash *hash, int64_t key) {
     return key % hash->size;
 }
 
-static inline RetVal serialOperations(void *h, ArgVal dummy_arg, int pid) {
+static RetVal serialOperations(void *h, ArgVal dummy_arg, int pid) {
     HashOperations arg;
     int64_t key;
     int64_t value;
@@ -95,7 +95,7 @@ static inline RetVal serialOperations(void *h, ArgVal dummy_arg, int pid) {
     }
 }
 
-inline bool CLHHashInsert(CLHHash *hash, CLHHashThreadState *th_state, int64_t key, int64_t value, int pid) {
+bool CLHHashInsert(CLHHash *hash, CLHHashThreadState *th_state, int64_t key, int64_t value, int pid) {
     HashOperations args;
     RetVal ret;
 
@@ -113,7 +113,7 @@ inline bool CLHHashInsert(CLHHash *hash, CLHHashThreadState *th_state, int64_t k
     return ret;
 }
 
-inline RetVal CLHHashSearch(CLHHash *hash, CLHHashThreadState *th_state, int64_t key, int pid) {
+RetVal CLHHashSearch(CLHHash *hash, CLHHashThreadState *th_state, int64_t key, int pid) {
     HashOperations args;
     RetVal ret;
 
@@ -131,7 +131,7 @@ inline RetVal CLHHashSearch(CLHHash *hash, CLHHashThreadState *th_state, int64_t
     return ret;
 }
 
-inline void CLHHashDelete(CLHHash *hash, CLHHashThreadState *th_state, int64_t key, int pid) {
+void CLHHashDelete(CLHHash *hash, CLHHashThreadState *th_state, int64_t key, int pid) {
     HashOperations args;
 
     args.op = HT_DELETE;

--- a/libconcurrent/concurrent/dsmhash.c
+++ b/libconcurrent/concurrent/dsmhash.c
@@ -1,12 +1,12 @@
 #include <dsmhash.h>
 #include <limits.h>
 
-static inline int64_t hash_func(DSMHash *hash, int64_t key);
-static inline RetVal serialOperations(void *h, ArgVal dummy_arg, int pid);
+static int64_t hash_func(DSMHash *hash, int64_t key);
+static RetVal serialOperations(void *h, ArgVal dummy_arg, int pid);
 
 static const int HT_INSERT = 0, HT_DELETE = 1, HT_SEARCH = 2;
 
-inline void DSMHashInit(DSMHash *hash, int num_cells, int nthreads) {
+void DSMHashInit(DSMHash *hash, int num_cells, int nthreads) {
     int i;
 
     hash->size = num_cells;
@@ -19,7 +19,7 @@ inline void DSMHashInit(DSMHash *hash, int num_cells, int nthreads) {
     }
 }
 
-inline void DSMHashThreadStateInit(DSMHash *hash, DSMHashThreadState *th_state, int num_cells, int pid) {
+void DSMHashThreadStateInit(DSMHash *hash, DSMHashThreadState *th_state, int num_cells, int pid) {
     int i;
 
     th_state->th_state = synchGetMemory(num_cells * sizeof(DSMSynchThreadState));
@@ -28,11 +28,11 @@ inline void DSMHashThreadStateInit(DSMHash *hash, DSMHashThreadState *th_state, 
         DSMSynchThreadStateInit(&hash->synch[i], &th_state->th_state[i], pid);
 }
 
-static inline int64_t hash_func(DSMHash *hash, int64_t key) {
+static int64_t hash_func(DSMHash *hash, int64_t key) {
     return key % hash->size;
 }
 
-static inline RetVal serialOperations(void *h, ArgVal dummy_arg, int pid) {
+static RetVal serialOperations(void *h, ArgVal dummy_arg, int pid) {
     HashOperations arg;
     int64_t key;
     int64_t value;
@@ -98,7 +98,7 @@ static inline RetVal serialOperations(void *h, ArgVal dummy_arg, int pid) {
     }
 }
 
-inline bool DSMHashInsert(DSMHash *hash, DSMHashThreadState *th_state, int64_t key, int64_t value, int pid) {
+bool DSMHashInsert(DSMHash *hash, DSMHashThreadState *th_state, int64_t key, int64_t value, int pid) {
     HashOperations args;
 
     args.op = HT_INSERT;
@@ -110,7 +110,7 @@ inline bool DSMHashInsert(DSMHash *hash, DSMHashThreadState *th_state, int64_t k
     return DSMSynchApplyOp(&hash->synch[args.cell], &th_state->th_state[args.cell], serialOperations, (void *)hash, 0, pid);
 }
 
-inline RetVal DSMHashSearch(DSMHash *hash, DSMHashThreadState *th_state, int64_t key, int pid) {
+RetVal DSMHashSearch(DSMHash *hash, DSMHashThreadState *th_state, int64_t key, int pid) {
     HashOperations args;
     RetVal ret;
 
@@ -125,7 +125,7 @@ inline RetVal DSMHashSearch(DSMHash *hash, DSMHashThreadState *th_state, int64_t
     return ret;
 }
 
-inline void DSMHashDelete(DSMHash *hash, DSMHashThreadState *th_state, int64_t key, int pid) {
+void DSMHashDelete(DSMHash *hash, DSMHashThreadState *th_state, int64_t key, int pid) {
     HashOperations args;
 
     args.op = HT_DELETE;

--- a/libconcurrent/concurrent/dsmqueue.c
+++ b/libconcurrent/concurrent/dsmqueue.c
@@ -1,8 +1,8 @@
 #include <dsmqueue.h>
 #include <pool.h>
 
-inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
-inline static RetVal serialDequeue(void *state, ArgVal arg, int pid);
+static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
+static RetVal serialDequeue(void *state, ArgVal arg, int pid);
 
 static __thread SynchPoolStruct pool_node CACHE_ALIGN;
 
@@ -21,7 +21,7 @@ void DSMQueueThreadStateInit(DSMQueueStruct *object_struct, DSMQueueThreadState 
     synchInitPool(&pool_node, sizeof(Node));
 }
 
-inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
+static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
     DSMQueueStruct *st = (DSMQueueStruct *)state;
     Node *node;
 
@@ -34,7 +34,7 @@ inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
     return ENQUEUE_SUCCESS;
 }
 
-inline static RetVal serialDequeue(void *state, ArgVal arg, int pid) {
+static RetVal serialDequeue(void *state, ArgVal arg, int pid) {
     DSMQueueStruct *st = (DSMQueueStruct *)state;
     volatile Node *node, *prev;
 

--- a/libconcurrent/concurrent/dsmqueue.c
+++ b/libconcurrent/concurrent/dsmqueue.c
@@ -4,7 +4,7 @@
 static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
 static RetVal serialDequeue(void *state, ArgVal arg, int pid);
 
-static __thread SynchPoolStruct pool_node CACHE_ALIGN;
+static _Thread_local SynchPoolStruct pool_node CACHE_ALIGN;
 
 void DSMQueueStructInit(DSMQueueStruct *queue_object_struct, uint32_t nthreads) {
     DSMSynchStructInit(&queue_object_struct->enqueue_struct, nthreads);

--- a/libconcurrent/concurrent/dsmstack.c
+++ b/libconcurrent/concurrent/dsmstack.c
@@ -1,7 +1,7 @@
 #include <dsmstack.h>
 #include <pool.h>
 
-inline static RetVal serialPushPop(void *state, ArgVal arg, int pid);
+static RetVal serialPushPop(void *state, ArgVal arg, int pid);
 
 static const int POP_OP = INT_MIN;
 static __thread SynchPoolStruct pool_node CACHE_ALIGN;
@@ -17,7 +17,7 @@ void DSMStackThreadStateInit(DSMStackStruct *object_struct, DSMStackThreadState 
     synchInitPool(&pool_node, sizeof(Node));
 }
 
-inline static RetVal serialPushPop(void *state, ArgVal arg, int pid) {
+static RetVal serialPushPop(void *state, ArgVal arg, int pid) {
     if (arg == POP_OP) {
         volatile DSMStackStruct *st = (DSMStackStruct *)state;
         volatile Node *node = st->top;

--- a/libconcurrent/concurrent/dsmstack.c
+++ b/libconcurrent/concurrent/dsmstack.c
@@ -4,7 +4,7 @@
 static RetVal serialPushPop(void *state, ArgVal arg, int pid);
 
 static const int POP_OP = INT_MIN;
-static __thread SynchPoolStruct pool_node CACHE_ALIGN;
+static _Thread_local SynchPoolStruct pool_node CACHE_ALIGN;
 
 void DSMSStackInit(DSMStackStruct *stack_object_struct, uint32_t nthreads) {
     DSMSynchStructInit(&stack_object_struct->object_struct, nthreads);

--- a/libconcurrent/concurrent/fcqueue.c
+++ b/libconcurrent/concurrent/fcqueue.c
@@ -4,8 +4,8 @@
 #include <pool.h>
 #include <queue-stack.h>
 
-inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
-inline static RetVal serialDequeue(void *state, ArgVal arg, int pid);
+static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
+static RetVal serialDequeue(void *state, ArgVal arg, int pid);
 
 static const int GUARD = INT_MIN;
 static __thread SynchPoolStruct pool_node CACHE_ALIGN;
@@ -25,7 +25,7 @@ void FCQueueThreadStateInit(FCQueueStruct *object_struct, FCQueueThreadState *lo
     synchInitPool(&pool_node, sizeof(Node));
 }
 
-inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
+static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
     FCQueueStruct *st = (FCQueueStruct *)state;
     Node *node;
     
@@ -37,7 +37,7 @@ inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
     return -1;
 }
 
-inline static RetVal serialDequeue(void *state, ArgVal arg, int pid) {
+static RetVal serialDequeue(void *state, ArgVal arg, int pid) {
     FCQueueStruct *st = (FCQueueStruct *)state;
     Node *node = (Node *)st->first;
     

--- a/libconcurrent/concurrent/fcqueue.c
+++ b/libconcurrent/concurrent/fcqueue.c
@@ -8,7 +8,7 @@ static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
 static RetVal serialDequeue(void *state, ArgVal arg, int pid);
 
 static const int GUARD = INT_MIN;
-static __thread SynchPoolStruct pool_node CACHE_ALIGN;
+static _Thread_local SynchPoolStruct pool_node CACHE_ALIGN;
 
 void FCQueueStructInit(FCQueueStruct *queue_object_struct, uint32_t nthreads) {
     FCStructInit(&queue_object_struct->enqueue_struct, nthreads);

--- a/libconcurrent/concurrent/fcstack.c
+++ b/libconcurrent/concurrent/fcstack.c
@@ -18,7 +18,7 @@ void FCStackThreadStateInit(FCStackStruct *object_struct, FCStackThreadState *lo
     synchInitPool(&pool_node, sizeof(Node));
 }
 
-inline static RetVal serialPushPop(void *state, ArgVal arg, int pid) {
+static RetVal serialPushPop(void *state, ArgVal arg, int pid) {
     if (arg == POP_OP) {
         volatile FCStackStruct *st = (FCStackStruct *)state;
         volatile Node *node = st->top;

--- a/libconcurrent/concurrent/fcstack.c
+++ b/libconcurrent/concurrent/fcstack.c
@@ -5,7 +5,7 @@
 #include <queue-stack.h>
 
 static const int POP_OP = INT_MIN;
-static __thread SynchPoolStruct pool_node CACHE_ALIGN;
+static _Thread_local SynchPoolStruct pool_node CACHE_ALIGN;
 
 void FCStackInit(FCStackStruct *stack_object_struct, uint32_t nthreads) {
     FCStructInit(&stack_object_struct->object_struct, nthreads);

--- a/libconcurrent/concurrent/hqueue.c
+++ b/libconcurrent/concurrent/hqueue.c
@@ -4,7 +4,7 @@
 static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
 static RetVal serialDequeue(void *state, ArgVal arg, int pid);
 
-static __thread SynchPoolStruct pool_node CACHE_ALIGN;
+static _Thread_local SynchPoolStruct pool_node CACHE_ALIGN;
 
 void HQueueInit(HQueueStruct *queue_object_struct, uint32_t nthreads, uint32_t numa_nodes) {
     queue_object_struct->enqueue_struct = synchGetAlignedMemory(S_CACHE_LINE_SIZE, sizeof(HSynchStruct));

--- a/libconcurrent/concurrent/hqueue.c
+++ b/libconcurrent/concurrent/hqueue.c
@@ -1,8 +1,8 @@
 #include <hqueue.h>
 #include <pool.h>
 
-inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
-inline static RetVal serialDequeue(void *state, ArgVal arg, int pid);
+static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
+static RetVal serialDequeue(void *state, ArgVal arg, int pid);
 
 static __thread SynchPoolStruct pool_node CACHE_ALIGN;
 
@@ -23,7 +23,7 @@ void HQueueThreadStateInit(HQueueStruct *object_struct, HQueueThreadState *lobje
     synchInitPool(&pool_node, sizeof(Node));
 }
 
-inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
+static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
     HQueueStruct *st = (HQueueStruct *)state;
     Node *node;
 
@@ -36,7 +36,7 @@ inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
     return ENQUEUE_SUCCESS;
 }
 
-inline static RetVal serialDequeue(void *state, ArgVal arg, int pid) {
+static RetVal serialDequeue(void *state, ArgVal arg, int pid) {
     HQueueStruct *st = (HQueueStruct *)state;
     volatile Node *node, *prev;
 

--- a/libconcurrent/concurrent/hstack.c
+++ b/libconcurrent/concurrent/hstack.c
@@ -4,7 +4,7 @@
 static RetVal serialPushPop(void *state, ArgVal arg, int pid);
 
 static const int POP_OP = INT_MIN;
-static __thread SynchPoolStruct pool_node CACHE_ALIGN;
+static _Thread_local SynchPoolStruct pool_node CACHE_ALIGN;
 
 void HStackInit(HStackStruct *stack_object_struct, uint32_t nthreads, uint32_t numa_nodes) {
     HSynchStructInit(&stack_object_struct->object_struct, nthreads, numa_nodes);

--- a/libconcurrent/concurrent/hstack.c
+++ b/libconcurrent/concurrent/hstack.c
@@ -1,7 +1,7 @@
 #include <hstack.h>
 #include <pool.h>
 
-inline static RetVal serialPushPop(void *state, ArgVal arg, int pid);
+static RetVal serialPushPop(void *state, ArgVal arg, int pid);
 
 static const int POP_OP = INT_MIN;
 static __thread SynchPoolStruct pool_node CACHE_ALIGN;
@@ -16,7 +16,7 @@ void HStackThreadStateInit(HStackStruct *object_struct, HStackThreadState *lobje
     synchInitPool(&pool_node, sizeof(Node));
 }
 
-inline RetVal serialPushPop(void *state, ArgVal arg, int pid) {
+RetVal serialPushPop(void *state, ArgVal arg, int pid) {
     if (arg == POP_OP) {
         volatile HStackStruct *st = (HStackStruct *)state;
         volatile Node *node = st->top;

--- a/libconcurrent/concurrent/hsynch.c
+++ b/libconcurrent/concurrent/hsynch.c
@@ -10,7 +10,7 @@
 #define HSYNCH_HELP_FACTOR            10
 #define HSYNCH_DEFAULT_NUMA_NODE_SIZE 8
 
-static __thread int node_of_thread = 0;
+static _Thread_local int node_of_thread = 0;
 
 RetVal HSynchApplyOp(HSynchStruct *l, HSynchThreadState *st_thread, RetVal (*sfunc)(void *, ArgVal, int), void *state, ArgVal arg, int pid) {
     volatile HSynchNode *p;

--- a/libconcurrent/concurrent/lcrq.c
+++ b/libconcurrent/concurrent/lcrq.c
@@ -43,30 +43,30 @@
 #include <primitives.h>
 #include <lcrq.h>
 
-inline static int is_empty(uint64_t v) __attribute__ ((pure));
-inline static uint64_t node_index(uint64_t i) __attribute__ ((pure));
-inline static uint64_t set_unsafe(uint64_t i) __attribute__ ((pure));
-inline static uint64_t node_unsafe(uint64_t i) __attribute__ ((pure));
-inline static uint64_t tail_index(uint64_t t) __attribute__ ((pure));
-inline static int crq_is_closed(uint64_t t) __attribute__ ((pure));
-inline static void fix_state(RingQueue *rq);
+static int is_empty(uint64_t v) __attribute__ ((pure));
+static uint64_t node_index(uint64_t i) __attribute__ ((pure));
+static uint64_t set_unsafe(uint64_t i) __attribute__ ((pure));
+static uint64_t node_unsafe(uint64_t i) __attribute__ ((pure));
+static uint64_t tail_index(uint64_t t) __attribute__ ((pure));
+static int crq_is_closed(uint64_t t) __attribute__ ((pure));
+static void fix_state(RingQueue *rq);
 
 #ifdef DEBUG
-inline static void count_closed_crq(LCRQThreadState *thread_state) {
+static void count_closed_crq(LCRQThreadState *thread_state) {
     thread_state->mycloses++;
 }
 
-inline static void count_unsafe_node(LCRQThreadState *thread_state) {
+static void count_unsafe_node(LCRQThreadState *thread_state) {
     thread_state->myunsafes++;
 }
 #else
-inline static void count_closed_crq(LCRQThreadState *thread_state) {
+static void count_closed_crq(LCRQThreadState *thread_state) {
 }
-inline static void count_unsafe_node(LCRQThreadState *thread_state) {
+static void count_unsafe_node(LCRQThreadState *thread_state) {
 }
 #endif
 
-inline static void init_ring(RingQueue *r) {
+static void init_ring(RingQueue *r) {
     int i;
 
     for (i = 0; i < RING_SIZE; i++) {
@@ -78,31 +78,31 @@ inline static void init_ring(RingQueue *r) {
     r->next = NULL;
 }
 
-inline static int is_empty(uint64_t v)  {
+static int is_empty(uint64_t v)  {
     return (v == (uint64_t)-1);
 }
 
-inline static uint64_t node_index(uint64_t i) {
+static uint64_t node_index(uint64_t i) {
     return (i & ~(1ull << 63));
 }
 
-inline static uint64_t set_unsafe(uint64_t i) {
+static uint64_t set_unsafe(uint64_t i) {
     return (i | (1ull << 63));
 }
 
-inline static uint64_t node_unsafe(uint64_t i) {
+static uint64_t node_unsafe(uint64_t i) {
     return (i & (1ull << 63));
 }
 
-inline static uint64_t tail_index(uint64_t t) {
+static uint64_t tail_index(uint64_t t) {
     return (t & ~(1ull << 63));
 }
 
-inline static int crq_is_closed(uint64_t t) {
+static int crq_is_closed(uint64_t t) {
     return (t & (1ull << 63)) != 0;
 }
 
-inline static void fix_state(RingQueue *rq) {
+static void fix_state(RingQueue *rq) {
     while (true) {
         uint64_t t = synchFAA64(&rq->tail, 0);
         uint64_t h = synchFAA64(&rq->head, 0);
@@ -117,7 +117,7 @@ inline static void fix_state(RingQueue *rq) {
     }
 }
 
-inline static int close_crq(RingQueue *rq, const uint64_t t, const int tries) {
+static int close_crq(RingQueue *rq, const uint64_t t, const int tries) {
     if (tries < 10)
         return synchCAS64(&rq->tail, t + 1, set_unsafe(t + 1));
     else

--- a/libconcurrent/concurrent/lfstack.c
+++ b/libconcurrent/concurrent/lfstack.c
@@ -1,16 +1,16 @@
 #include <lfstack.h>
 
-inline void LFStackInit(LFStackStruct *l) {
+void LFStackInit(LFStackStruct *l) {
     l->top = NULL;
     synchFullFence();
 }
 
-inline void LFStackThreadStateInit(LFStackThreadState *th_state, int min_back, int max_back) {
+void LFStackThreadStateInit(LFStackThreadState *th_state, int min_back, int max_back) {
     synchInitBackoff(&th_state->backoff, min_back, max_back, 1);
     synchInitPool(&th_state->pool, sizeof(Node));
 }
 
-inline void LFStackPush(LFStackStruct *l, LFStackThreadState *th_state, ArgVal arg) {
+void LFStackPush(LFStackStruct *l, LFStackThreadState *th_state, ArgVal arg) {
     Node *n;
 
     n = synchAllocObj(&th_state->pool);
@@ -26,7 +26,7 @@ inline void LFStackPush(LFStackStruct *l, LFStackThreadState *th_state, ArgVal a
     } while (true);
 }
 
-inline RetVal LFStackPop(LFStackStruct *l, LFStackThreadState *th_state) {
+RetVal LFStackPop(LFStackStruct *l, LFStackThreadState *th_state) {
     synchResetBackoff(&th_state->backoff);
     do {
         Node *old_top = (Node *)l->top;

--- a/libconcurrent/concurrent/osciqueue.c
+++ b/libconcurrent/concurrent/osciqueue.c
@@ -1,8 +1,8 @@
 #include <osciqueue.h>
 #include <threadtools.h>
 
-inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
-inline static RetVal serialDequeue(void *state, ArgVal arg, int pid);
+static RetVal serialEnqueue(void *state, ArgVal arg, int pid);
+static RetVal serialDequeue(void *state, ArgVal arg, int pid);
 
 void OsciQueueInit(OsciQueueStruct *queue_object_struct, uint32_t nthreads, uint32_t fibers_per_thread) {
     OsciInit(&(queue_object_struct->enqueue_struct), nthreads, fibers_per_thread);
@@ -20,7 +20,7 @@ void OsciQueueThreadStateInit(OsciQueueStruct *object_struct, OsciQueueThreadSta
     synchInitPool(&(object_struct->pool_node[synchGetThreadId()]), sizeof(Node));
 }
 
-inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
+static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
     OsciQueueStruct *st = (OsciQueueStruct *)state;
     Node *node;
 
@@ -32,7 +32,7 @@ inline static RetVal serialEnqueue(void *state, ArgVal arg, int pid) {
     return ENQUEUE_SUCCESS;
 }
 
-inline static RetVal serialDequeue(void *state, ArgVal arg, int pid) {
+static RetVal serialDequeue(void *state, ArgVal arg, int pid) {
     OsciQueueStruct *st = (OsciQueueStruct *)state;
     volatile Node *node, *prev;
 

--- a/libconcurrent/concurrent/oscistack.c
+++ b/libconcurrent/concurrent/oscistack.c
@@ -1,7 +1,7 @@
 #include <oscistack.h>
 #include <threadtools.h>
 
-inline static RetVal serialPushPop(void *state, ArgVal arg, int pid);
+static RetVal serialPushPop(void *state, ArgVal arg, int pid);
 
 static const int POP_OP = INT_MIN;
 
@@ -16,7 +16,7 @@ void OsciStackThreadStateInit(OsciStackStruct *object_struct, OsciStackThreadSta
     synchInitPool(&(object_struct->pool_node[synchGetThreadId()]), sizeof(Node));
 }
 
-inline static RetVal serialPushPop(void *state, ArgVal arg, int pid) {
+static RetVal serialPushPop(void *state, ArgVal arg, int pid) {
     if (arg == POP_OP) {
         volatile OsciStackStruct *st = (OsciStackStruct *)state;
         volatile Node *node = st->top;

--- a/libconcurrent/concurrent/oyama.c
+++ b/libconcurrent/concurrent/oyama.c
@@ -1,7 +1,7 @@
 #include <oyama.h>
 #include <threadtools.h>
 
-inline static void OyamaWait(void);
+static void OyamaWait(void);
 
 const int LOCKED = 1;
 const int UNLOCKED = 0;

--- a/libconcurrent/concurrent/sim.c
+++ b/libconcurrent/concurrent/sim.c
@@ -2,9 +2,9 @@
 #include <fastrand.h>
 #include <threadtools.h>
 
-static inline void SimStateCopy(SimObjectState *dest, SimObjectState *src);
+static void SimStateCopy(SimObjectState *dest, SimObjectState *src);
 
-static inline void SimStateCopy(SimObjectState *dest, SimObjectState *src) {
+static void SimStateCopy(SimObjectState *dest, SimObjectState *src) {
     // copy everything except 'applied' and 'ret' fields
     memcpy(&dest->state, &src->state, SimObjectStateSize(dest->applied.nthreads) - CACHE_LINE_SIZE);
 }

--- a/libconcurrent/concurrent/simqueue.c
+++ b/libconcurrent/concurrent/simqueue.c
@@ -4,18 +4,18 @@
 
 static const int LOCAL_POOL_SIZE = _SIM_LOCAL_POOL_SIZE_;
 
-static inline void EnqStateCopy(EnqState *dest, EnqState *src);
-static inline void DeqStateCopy(DeqState *dest, DeqState *src);
-static inline void EnqLinkQueue(SimQueueStruct *queue, EnqState *pst);
-static inline void DeqLinkQueue(SimQueueStruct *queue, DeqState *pst);
+static void EnqStateCopy(EnqState *dest, EnqState *src);
+static void DeqStateCopy(DeqState *dest, DeqState *src);
+static void EnqLinkQueue(SimQueueStruct *queue, EnqState *pst);
+static void DeqLinkQueue(SimQueueStruct *queue, DeqState *pst);
 
-inline static void EnqLinkQueue(SimQueueStruct *queue, EnqState *pst) {
+static void EnqLinkQueue(SimQueueStruct *queue, EnqState *pst) {
     if (pst->first != NULL) {
         synchCASPTR(&pst->first->next, NULL, pst->last);
     }
 }
 
-inline static void DeqLinkQueue(SimQueueStruct *queue, DeqState *pst) {
+static void DeqLinkQueue(SimQueueStruct *queue, DeqState *pst) {
     pointer_t enq_sp;
     EnqState *enq_pst;
 
@@ -30,13 +30,13 @@ inline static void DeqLinkQueue(SimQueueStruct *queue, DeqState *pst) {
     }
 }
 
-static inline void EnqStateCopy(EnqState *dest, EnqState *src) {
+static void EnqStateCopy(EnqState *dest, EnqState *src) {
     // copy everything except 'applied'
     memcpy(&dest->copy_point, &src->copy_point,
            EnqStateSize(src->applied.nthreads) - sizeof(ToggleVector));
 }
 
-static inline void DeqStateCopy(DeqState *dest, DeqState *src) {
+static void DeqStateCopy(DeqState *dest, DeqState *src) {
     // copy everything except 'applied' and 'ret' fields
     memcpy(&dest->copy_point, &src->copy_point,
            DeqStateSize(src->applied.nthreads)- sizeof(ToggleVector) - sizeof(RetVal *));

--- a/libconcurrent/concurrent/simstack.c
+++ b/libconcurrent/concurrent/simstack.c
@@ -13,13 +13,13 @@
 
 static const uint64_t POP = LLONG_MIN;
 
-inline static void serialPush(HalfSimStackState *st, SimStackThreadState *th_state, ArgVal arg);
-inline static bool serialPop(HalfSimStackState *st, int pid);
-inline static RetVal SimStackApplyOp(SimStackStruct *stack, SimStackThreadState *th_state, ArgVal arg, int pid);
-static inline void SimStackStateCopy(SimStackState *dest, SimStackState *src);
-inline static void recycleList(SynchPoolStruct *pool, Node *head, uint32_t items);
+static void serialPush(HalfSimStackState *st, SimStackThreadState *th_state, ArgVal arg);
+static bool serialPop(HalfSimStackState *st, int pid);
+static RetVal SimStackApplyOp(SimStackStruct *stack, SimStackThreadState *th_state, ArgVal arg, int pid);
+static void SimStackStateCopy(SimStackState *dest, SimStackState *src);
+static void recycleList(SynchPoolStruct *pool, Node *head, uint32_t items);
 
-static inline void SimStackStateCopy(SimStackState *dest, SimStackState *src) {
+static void SimStackStateCopy(SimStackState *dest, SimStackState *src) {
     // copy everything except 'applied' and 'ret' fields
     memcpy(&dest->head, &src->head, SimStackStateSize(dest->applied.nthreads) - sizeof(ToggleVector) - sizeof(Object *));
 }
@@ -65,7 +65,7 @@ void SimStackThreadStateInit(SimStackThreadState *th_state, uint32_t nthreads, i
     synchInitPool(&th_state->pool, sizeof(Node));
 }
 
-inline static void recycleList(SynchPoolStruct *pool, Node *head, uint32_t items) {
+static void recycleList(SynchPoolStruct *pool, Node *head, uint32_t items) {
     while (items > 0) {
         Node *node = head;
         head = (Node *)head->next;
@@ -74,7 +74,7 @@ inline static void recycleList(SynchPoolStruct *pool, Node *head, uint32_t items
     }
 }
 
-inline static void serialPush(HalfSimStackState *st, SimStackThreadState *th_state, ArgVal arg) {
+static void serialPush(HalfSimStackState *st, SimStackThreadState *th_state, ArgVal arg) {
 #ifdef DEBUG
     st->counter += 1;
 #endif
@@ -85,7 +85,7 @@ inline static void serialPush(HalfSimStackState *st, SimStackThreadState *th_sta
     st->head = n;
 }
 
-inline static bool serialPop(HalfSimStackState *st, int pid) {
+static bool serialPop(HalfSimStackState *st, int pid) {
 #ifdef DEBUG
     st->counter += 1;
 #endif
@@ -99,7 +99,7 @@ inline static bool serialPop(HalfSimStackState *st, int pid) {
     }
 }
 
-inline static RetVal SimStackApplyOp(SimStackStruct *stack, SimStackThreadState *th_state, ArgVal arg, int pid) {
+static RetVal SimStackApplyOp(SimStackStruct *stack, SimStackThreadState *th_state, ArgVal arg, int pid) {
     ToggleVector *diffs = &th_state->diffs, *l_toggles = &th_state->l_toggles, *pops = &th_state->pops;
     pointer_t new_sp, old_sp;
     HalfSimStackState *lsp_data, *sp_data;

--- a/libconcurrent/includes/barrier.h
+++ b/libconcurrent/includes/barrier.h
@@ -29,20 +29,20 @@ typedef struct SynchBarrier {
 ///
 /// @param bar A pointer to an instance of the barrier object.
 /// @param n The number of threads that will use the barrier object.
-inline void synchBarrierSet(SynchBarrier *bar, uint32_t n);
+void synchBarrierSet(SynchBarrier *bar, uint32_t n);
 
 /// @brief Whenever a thread executes this function, it waits without returning 
 /// until all the other n-1 threads also execute the same function.
 /// @param bar A pointer to an instance of the barrier object.
-inline void synchBarrierWait(SynchBarrier *bar);
+void synchBarrierWait(SynchBarrier *bar);
 
 /// @brief Whenever a thread executes this function, it states that it will no use this barrier instance anymore. 
 /// Thus, the system may free some resources.
 /// @param bar A pointer to an instance of the barrier object.
-inline void synchBarrierLeave(SynchBarrier *bar);
+void synchBarrierLeave(SynchBarrier *bar);
 
 /// @brief Deprecated functionality. It is only used in the threadtools.c file.
 /// @param bar A pointer to an instance of the barrier object.
-inline void synchBarrierLastLeave(SynchBarrier *bar);
+void synchBarrierLastLeave(SynchBarrier *bar);
 
 #endif

--- a/libconcurrent/includes/clhhash.h
+++ b/libconcurrent/includes/clhhash.h
@@ -74,7 +74,7 @@ typedef struct CLHHashThreadState {
 /// @param hash A pointer to the hash-table instance.
 /// @param num_cells The number of cells that the hash-table object is going to use.
 /// @param nthreads The number of threads that will use the CLH-Hash object.
-inline void CLHHashStructInit(CLHHash *hash, int num_cells, int nthreads);
+void CLHHashStructInit(CLHHash *hash, int num_cells, int nthreads);
 
 /// @brief This function should be called once before the thread applies any operation to the CLH-Hash combining object.
 ///
@@ -82,7 +82,7 @@ inline void CLHHashStructInit(CLHHash *hash, int num_cells, int nthreads);
 /// @param th_state A pointer to thread's local state of CLH-Hash.
 /// @param num_cells The number of cells that the hash-table object is going to use.
 /// @param pid The pid of the calling thread.
-inline void CLHHashThreadStateInit(CLHHash *hash, CLHHashThreadState *th_state, int num_cells, int pid);
+void CLHHashThreadStateInit(CLHHash *hash, CLHHashThreadState *th_state, int num_cells, int pid);
 
 /// @brief This function tries to insert a <key,value> into the hash-table if there is enough space in the
 /// corresponding cell. If the key already exists in the hash-table, CLHHashInsert updates the corresponding value.
@@ -93,7 +93,7 @@ inline void CLHHashThreadStateInit(CLHHash *hash, CLHHashThreadState *th_state, 
 /// @param value The value of the <key,value> pair that CLHHashInsert will try to insert into the hash-table.
 /// @param pid The pid of the calling thread.
 /// @return In case of success true is returned. In case that there is not enough space in the corresponding cell.
-inline bool CLHHashInsert(CLHHash *hash, CLHHashThreadState *th_state, int64_t key, int64_t value, int pid);
+bool CLHHashInsert(CLHHash *hash, CLHHashThreadState *th_state, int64_t key, int64_t value, int pid);
 
 /// @brief This function searches for a specific key in the hash-table. In case that CLHHashSearch finds the key,
 /// it returns true. Otherwise, it returns false.
@@ -103,7 +103,7 @@ inline bool CLHHashInsert(CLHHash *hash, CLHHashThreadState *th_state, int64_t k
 /// @param key The key of the <key,value> pair that CLHHashSearch will search for.
 /// @param pid The pid of the calling thread.
 /// @return CLHHashSearch returns the value of the <key,value> pair in case that the key exists in the hash-table.
-inline RetVal CLHHashSearch(CLHHash *hash, CLHHashThreadState *th_state, int64_t key, int pid);
+RetVal CLHHashSearch(CLHHash *hash, CLHHashThreadState *th_state, int64_t key, int pid);
 
 /// @brief This function searches for a specific key in the hash-table. In case that CLHHashDelete finds the key,
 /// it deletes the corresponding <key,value>.
@@ -112,6 +112,6 @@ inline RetVal CLHHashSearch(CLHHash *hash, CLHHashThreadState *th_state, int64_t
 /// @param th_state A pointer to thread's local state of CLH-Hash.
 /// @param key The key of the <key,value> pair that CLHHashDelete will try to delete it.
 /// @param pid The pid of the calling thread.
-inline void CLHHashDelete(CLHHash *hash, CLHHashThreadState *th_state, int64_t key, int pid);
+void CLHHashDelete(CLHHash *hash, CLHHashThreadState *th_state, int64_t key, int pid);
 
 #endif

--- a/libconcurrent/includes/dsmhash.h
+++ b/libconcurrent/includes/dsmhash.h
@@ -74,7 +74,7 @@ typedef struct DSMHashThreadState {
 /// @param hash A pointer to the hash-table instance.
 /// @param num_cells The number of cells that the hash-table object is going to use.
 /// @param nthreads The number of threads that will use the DSM-Hash object.
-inline void DSMHashInit(DSMHash *hash, int num_cells, int nthreads);
+void DSMHashInit(DSMHash *hash, int num_cells, int nthreads);
 
 /// @brief This function should be called once before the thread applies any operation to the DSM-Hash combining object.
 ///
@@ -82,7 +82,7 @@ inline void DSMHashInit(DSMHash *hash, int num_cells, int nthreads);
 /// @param th_state A pointer to thread's local state of DSM-Hash.
 /// @param num_cells The number of cells that the hash-table object is going to use.
 /// @param pid The pid of the calling thread.
-inline void DSMHashThreadStateInit(DSMHash *hash, DSMHashThreadState *th_state, int num_cells, int pid);
+void DSMHashThreadStateInit(DSMHash *hash, DSMHashThreadState *th_state, int num_cells, int pid);
 
 /// @brief This function tries to insert a <key,value> into the hash-table if there is enough space in the
 /// corresponding cell. If the key already exists in the hash-table, DSMHashInsert updates the corresponding value.
@@ -93,7 +93,7 @@ inline void DSMHashThreadStateInit(DSMHash *hash, DSMHashThreadState *th_state, 
 /// @param value The value of the <key,value> pair that DSMHashInsert will try to insert into the hash-table.
 /// @param pid The pid of the calling thread.
 /// @return In case of success true is returned. In case that there is not enough space in the corresponding cell.
-inline bool DSMHashInsert(DSMHash *hash, DSMHashThreadState *th_state, int64_t key, int64_t value, int pid);
+bool DSMHashInsert(DSMHash *hash, DSMHashThreadState *th_state, int64_t key, int64_t value, int pid);
 
 /// @brief This function searches for a specific key in the hash-table. In case that DSMHashSearch finds the key,
 /// it returns true. Otherwise, it returns false.
@@ -103,7 +103,7 @@ inline bool DSMHashInsert(DSMHash *hash, DSMHashThreadState *th_state, int64_t k
 /// @param key The key of the <key,value> pair that DSMHashSearch will search for.
 /// @param pid The pid of the calling thread.
 /// @return DSMHashSearch returns the value of the <key,value> pair in case that the key exists in the hash-table.
-inline RetVal DSMHashSearch(DSMHash *hash, DSMHashThreadState *th_state, int64_t key, int pid);
+RetVal DSMHashSearch(DSMHash *hash, DSMHashThreadState *th_state, int64_t key, int pid);
 
 /// @brief This function searches for a specific key in the hash-table. In case that DSMHashDelete finds the key,
 /// it deletes the corresponding <key,value>.
@@ -112,6 +112,6 @@ inline RetVal DSMHashSearch(DSMHash *hash, DSMHashThreadState *th_state, int64_t
 /// @param th_state A pointer to thread's local state of DSM-Hash.
 /// @param key The key of the <key,value> pair that DSMHashDelete will try to delete it.
 /// @param pid The pid of the calling thread.
-inline void DSMHashDelete(DSMHash *hash, DSMHashThreadState *th_state, int64_t key, int pid);
+void DSMHashDelete(DSMHash *hash, DSMHashThreadState *th_state, int64_t key, int pid);
 
 #endif

--- a/libconcurrent/includes/fam.h
+++ b/libconcurrent/includes/fam.h
@@ -22,7 +22,7 @@ typedef union ObjectState {
 /// @param arg The argument of the operation.
 /// @param pid The pid of the calling thread.
 /// @return The result of the serial Fetch&Multiply operation.
-inline static RetVal fetchAndMultiply(void *state, ArgVal arg, int pid) {
+static inline RetVal fetchAndMultiply(void *state, ArgVal arg, int pid) {
     ObjectState *obj = (ObjectState *)state;
     ObjectState res;
 

--- a/libconcurrent/includes/primitives.h
+++ b/libconcurrent/includes/primitives.h
@@ -44,9 +44,9 @@
 #    define synchUnlikely(A)            __builtin_expect(!!(A), 0)
 #    define UNUSED_ARG                  __attribute__((unused))
 #    if defined(__amd64__) || defined(__x86_64__)
-#        define synchLoadFence()  asm volatile("lfence" ::: "memory")
-#        define synchStoreFence() asm volatile("sfence" ::: "memory")
-#        define synchFullFence()  asm volatile("mfence" ::: "memory")
+#        define synchLoadFence()  __asm__ volatile("lfence" ::: "memory")
+#        define synchStoreFence() __asm__ volatile("sfence" ::: "memory")
+#        define synchFullFence()  __asm__ volatile("mfence" ::: "memory")
 #        define synchNonTSOFence()
 #    else
 #        define synchLoadFence()   __sync_synchronize()
@@ -57,19 +57,19 @@
 #elif defined(__GNUC__) && (defined(__amd64__) || defined(__x86_64__))
 #    warning You may lose performance!
 #    warning A newer version of GCC compiler is recommended!
-#    define synchLoadFence()      asm volatile("lfence" ::: "memory")
-#    define synchStoreFence()     asm volatile("sfence" ::: "memory")
-#    define synchFullFence()      asm volatile("mfence" ::: "memory")
-#    define synchReadPrefetch(A)  asm volatile("prefetchnta %0" ::"m"(*((const int *)A)))
-#    define synchStorePrefetch(A) asm volatile("prefetchnta %0" ::"m"(*((const int *)A)))
+#    define synchLoadFence()      __asm__ volatile("lfence" ::: "memory")
+#    define synchStoreFence()     __asm__ volatile("sfence" ::: "memory")
+#    define synchFullFence()      __asm__ volatile("mfence" ::: "memory")
+#    define synchReadPrefetch(A)  __asm__ volatile("prefetchnta %0" ::"m"(*((const int *)A)))
+#    define synchStorePrefetch(A) __asm__ volatile("prefetchnta %0" ::"m"(*((const int *)A)))
 #    define synchNonTSOFence()
 #    define synchLikely(A)   (A)
 #    define synchUnlikely(A) (A)
 #    define UNUSED_ARG       __attribute__((unused))
 //   in this case where gcc is too old, implement atomic primitives in primitives.c
 #    define __OLD_GCC_X86__
-inline int synchBitSearchFirst(uint64_t B);
-inline uint64_t synchNonZeroBits(uint64_t v);
+int synchBitSearchFirst(uint64_t B);
+uint64_t synchNonZeroBits(uint64_t v);
 #else
 #    error Current machine architecture and compiler are not supported yet!
 #endif
@@ -89,10 +89,10 @@ inline uint64_t synchNonZeroBits(uint64_t v);
             if (synchGetMachineModel() != INTEL_X86_MACHINE)                                                                                                                                           \
                 return;                                                                                                                                                                                \
             for (__i = 0; __i < 16; __i++) {                                                                                                                                                           \
-                asm volatile("pause");                                                                                                                                                                 \
-                asm volatile("pause");                                                                                                                                                                 \
-                asm volatile("pause");                                                                                                                                                                 \
-                asm volatile("pause");                                                                                                                                                                 \
+                __asm__ volatile("pause");                                                                                                                                                                 \
+                __asm__ volatile("pause");                                                                                                                                                                 \
+                __asm__ volatile("pause");                                                                                                                                                                 \
+                __asm__ volatile("pause");                                                                                                                                                                 \
             }                                                                                                                                                                                          \
         }
 #else
@@ -105,7 +105,7 @@ inline uint64_t synchNonZeroBits(uint64_t v);
 ///
 /// @param size The size of the memory area.
 /// @return In case of error, NULL is returned. In case of success a pointer to the allocated memory area is returned.
-inline void *synchGetMemory(size_t size);
+void *synchGetMemory(size_t size);
 
 /// @brief This function allocates a memory area of size bytes. The returned address is aligned to an offset equal to align bytes.
 /// In case that SYNCH_NUMA_SUPPORT is defined in libconcurrent/config.h, the returned memory is allocated on the local NUMA node.
@@ -113,18 +113,18 @@ inline void *synchGetMemory(size_t size);
 /// @param align The alignment size.
 /// @param size The size of the memory area.
 /// @return In case of error, NULL is returned. In case of success a pointer to the allocated memory area is returned.
-inline void *synchGetAlignedMemory(size_t align, size_t size);
+void *synchGetAlignedMemory(size_t align, size_t size);
 
 /// @brief This function frees memory allocated with either getMemory() or synchGetAlignedMemory() functions.
 ///
 /// @param ptr A pointer to the memory area to be freed.
 /// @param size The size of the memory area to be freed.
-inline void synchFreeMemory(void *ptr, size_t size);
+void synchFreeMemory(void *ptr, size_t size);
 
 /// @brief This function returns the current system's time in milliseconds.
 ///
 /// @return System's time in milliseconds.
-inline int64_t synchGetTimeMillis(void);
+int64_t synchGetTimeMillis(void);
 
 /// @brief This function returns the vendor of the processor that it runs on.
 /// The current version of the Synch framework returns any of the following codes:
@@ -136,7 +136,7 @@ inline int64_t synchGetTimeMillis(void);
 /// - UNKNOWN_MACHINE
 ///
 /// @return It returns a code for the vendor of the processor that it runs on.
-inline uint64_t synchGetMachineModel(void);
+uint64_t synchGetMachineModel(void);
 
 /// A wrapper for the _CAS128 function. See more on _CAS128().
 #define synchCAS128(A, B0, B1, C0, C1) _CAS128((uint64_t *)(A), (uint64_t)(B0), (uint64_t)(B1), (uint64_t)(C0), (uint64_t)(C1))
@@ -152,7 +152,7 @@ inline uint64_t synchGetMachineModel(void);
 /// @param C1 The most significant 64-bits of the new value.
 /// @return This function computes '(A0 == B0 & A1 == B1) ? <C0,C1> : <A0,A1>' and stores the result at location pointed by A.
 /// The function returns in case that (A0 == B0 & A1 == B1) is true. Otherwise, it returns false.
-inline bool _CAS128(uint64_t *A, uint64_t B0, uint64_t B1, uint64_t C0, uint64_t C1);
+bool _CAS128(uint64_t *A, uint64_t B0, uint64_t B1, uint64_t C0, uint64_t C1);
 
 /// A wrapper for the _CASPTR function. See more on _CASPTR().
 #define synchCASPTR(A, B, C) _CASPTR((void *)(A), (void *)(B), (void *)(C))
@@ -164,7 +164,7 @@ inline bool _CAS128(uint64_t *A, uint64_t B0, uint64_t B1, uint64_t C0, uint64_t
 /// @param B The old value.
 /// @param C The new value.
 /// @return The function returns in case that (OLD == B) is true. Otherwise, it returns false.
-inline bool _CASPTR(void *A, void *B, void *C);
+bool _CASPTR(void *A, void *B, void *C);
 
 /// A wrapper for the _CAS64 function. See more on _CAS64().
 #define synchCAS64(A, B, C) _CAS64((uint64_t *)(A), (uint64_t)(B), (uint64_t)(C))
@@ -176,7 +176,7 @@ inline bool _CASPTR(void *A, void *B, void *C);
 /// @param B The old value (64-bits).
 /// @param C The new value (64-bits).
 /// @return The function returns in case that (OLD == B) is true. Otherwise, it returns false.
-inline bool _CAS64(uint64_t *A, uint64_t B, uint64_t C);
+bool _CAS64(uint64_t *A, uint64_t B, uint64_t C);
 
 /// A wrapper for the _CAS32 function. See more on _CAS32().
 #define synchCAS32(A, B, C) _CAS32((uint32_t *)(A), (uint32_t)(B), (uint32_t)(C))
@@ -188,7 +188,7 @@ inline bool _CAS64(uint64_t *A, uint64_t B, uint64_t C);
 /// @param B The old value (32-bits).
 /// @param C The new value (32-bits).
 /// @return The function returns in case that (OLD == B) is true. Otherwise, it returns false.
-inline bool _CAS32(uint32_t *A, uint32_t B, uint32_t C);
+bool _CAS32(uint32_t *A, uint32_t B, uint32_t C);
 
 /// A wrapper for the _SWAP function. See more on _SWAP().
 #define synchSWAP(A, B) _SWAP((void *)(A), (void *)(B))
@@ -198,7 +198,7 @@ inline bool _CAS32(uint32_t *A, uint32_t B, uint32_t C);
 /// @param A A pointer to memory location that stores a memory pointer.
 /// @param B The new value to be stored in the memory location pointed by A.
 /// @return It returns the old value of the memory location pointed by A just before the operation. 
-inline void *_SWAP(void *A, void *B);
+void *_SWAP(void *A, void *B);
 
 /// A wrapper for the _FAA32 function. See more on _FAA32().
 #define synchFAA32(A, B) _FAA32((volatile int32_t *)(A), (int32_t)(B))
@@ -208,7 +208,7 @@ inline void *_SWAP(void *A, void *B);
 /// @param A A pointer to memory location that stores a 32-bit integer.
 /// @param B A 32-bit integer to be added to the value pointed by A.
 /// @return It returns the old 32-bit value of the memory location pointed by A just before the operation.
-inline int32_t _FAA32(volatile int32_t *A, int32_t B);
+int32_t _FAA32(volatile int32_t *A, int32_t B);
 
 /// A wrapper for the _FAA64 function. See more on _FAA64().
 #define synchFAA64(A, B) _FAA64((volatile int64_t *)(A), (int64_t)(B))
@@ -218,7 +218,7 @@ inline int32_t _FAA32(volatile int32_t *A, int32_t B);
 /// @param A A pointer to memory location that stores a 64-bit integer.
 /// @param B A 64-bit integer to be added to the value pointed by A.
 /// @return It returns the old 64-bit value of the memory location pointed by A just before the operation.
-inline int64_t _FAA64(volatile int64_t *A, int64_t B);
+int64_t _FAA64(volatile int64_t *A, int64_t B);
 
 /// A wrapper for the _BitTAS64 function. See more on _BitTAS64().
 #define synchBitTAS64(A, B) _BitTAS64((volatile uint64_t *)(A), (unsigned char)(B))
@@ -227,6 +227,6 @@ inline int64_t _FAA64(volatile int64_t *A, int64_t B);
 /// @param A A pointer to memory location that stores a 64-bit value.
 /// @param B The B-th bit of the value stored in the memory location pointed by A.
 /// @return The result of Test&Set on the B-th bit of the value pointed by A.
-inline uint64_t _BitTAS64(volatile uint64_t *A, unsigned char B);
+uint64_t _BitTAS64(volatile uint64_t *A, unsigned char B);
 
 #endif

--- a/libconcurrent/includes/serialheap.h
+++ b/libconcurrent/includes/serialheap.h
@@ -59,7 +59,7 @@ typedef struct SerialHeapStruct {
 
 /// @brief This function initializes an instance of the serial heap implementation.
 /// This function should be called before any operation is applied to the heap.
-inline void serialHeapInit(SerialHeapStruct *heap_state, uint32_t type);
+void serialHeapInit(SerialHeapStruct *heap_state, uint32_t type);
 
 /// @brief This function provides all the operations (i.e. insert an element, removing the minimum 
 /// and getting the minimum) provided by this serial heap implementation.
@@ -79,13 +79,13 @@ inline void serialHeapInit(SerialHeapStruct *heap_state, uint32_t type);
 /// otherwise the value of the minimum element is returned.
 /// (iii) Inserting a new element; SYNCH_HEAP_INSERT_FAIL is returned in case that there is 
 /// no space available in the heap, otherwise SYNCH_HEAP_INSERT_SUCCESS nis returned.
-inline RetVal serialHeapApplyOperation(void *state, ArgVal arg, int pid);
+RetVal serialHeapApplyOperation(void *state, ArgVal arg, int pid);
 
 /// @brief This functions empties the heap from data by continuously executing HeapDeleteMinMax
 /// operations. Moreover, if validates the ordering of the removed items.
 /// @param heap_state A pointer to a heap object.
 /// @return In case that the ordering of the removing items is valid, true is returned.
 /// Otherwise, false is returned.
-inline bool serialHeapClearAndValidation(SerialHeapStruct *heap_state);
+bool serialHeapClearAndValidation(SerialHeapStruct *heap_state);
 
 #endif

--- a/libconcurrent/includes/threadtools.h
+++ b/libconcurrent/includes/threadtools.h
@@ -96,38 +96,38 @@ uint32_t synchGetThreadPlacementPolicy(void);
 /// should be a unique integer in {0, ..., N-1}, where N is the amount of available processing cores.
 int synchThreadPin(int32_t cpu_id);
 
-inline uint32_t synchPreferredNumaNodeOfThread(uint32_t pid);
+uint32_t synchPreferredNumaNodeOfThread(uint32_t pid);
 
 /// @brief This function returns the id of the running thread (posix or fiber). More specifically, it returns
 /// a unique integer in {0, ..., N-1}, where N is the amount of the running threads. For example, if 3 Posix threads
 /// are running, and 4 fiber threads are running inside each Posix thread, this function will return an integer
 /// in the interval of {0, ...., 11}.
-inline int32_t synchGetThreadId(void);
+int32_t synchGetThreadId(void);
 
-inline int32_t synchGetPreferredNumaNode(void);
+int32_t synchGetPreferredNumaNode(void);
 
 /// @brief This fuction returns the id of the current posix thread. 
 /// This function should return an identical value for any fiber running in the same posix thread.
-inline int32_t synchGetPosixThreadId(void);
+int32_t synchGetPosixThreadId(void);
 
 /// @brief This function returns the core-id of the current posix thread or fiber. The core-id is a
 /// unique integer in {0, ..., N-1}, where N is the amount of available processing cores.
-inline int32_t synchGetPreferredCore(void);
+int32_t synchGetPreferredCore(void);
 
 /// @brief This function returns the core-id of the posix thread or fiber with id equal to pid. 
 /// The core-id is a unique integer in {0, ..., N-1}, where N is the amount of available processing cores.
-inline uint32_t synchPreferredCoreOfThread(uint32_t pid);
+uint32_t synchPreferredCoreOfThread(uint32_t pid);
 
 /// @brief This function returns the number of system's processing cores.
-inline uint32_t synchGetNCores(void);
+uint32_t synchGetNCores(void);
 
 /// @brief In case that this function is called by a posix thread, it hints OS to give the CPU to
 /// some other thread. In case that this function is called by a fiber, it gives the CPU control 
 /// to the next fiber (if any) running in the same posix thread.
-inline void synchResched(void);
+void synchResched(void);
 
 /// @brief This function returns true if the number of spawned threads is greater than the number of 
 /// system's available processing cores; otherwise, this function returns false.
-inline bool synchIsSystemOversubscribed(void);
+bool synchIsSystemOversubscribed(void);
 
 #endif

--- a/libconcurrent/primitives/barrier.c
+++ b/libconcurrent/primitives/barrier.c
@@ -2,7 +2,7 @@
 #include <primitives.h>
 #include <threadtools.h>
 
-inline void synchBarrierSet(SynchBarrier *bar, uint32_t n) {
+void synchBarrierSet(SynchBarrier *bar, uint32_t n) {
     bar->arrive = n;
     bar->leave = n;
     bar->arrive_flag = true;
@@ -11,7 +11,7 @@ inline void synchBarrierSet(SynchBarrier *bar, uint32_t n) {
     synchFullFence();
 }
 
-inline void synchBarrierWait(SynchBarrier *bar) {
+void synchBarrierWait(SynchBarrier *bar) {
     if (synchFAA32(&bar->arrive, -1) > 1) {
         while (bar->arrive_flag)
             synchResched();
@@ -38,12 +38,12 @@ inline void synchBarrierWait(SynchBarrier *bar) {
     }
 }
 
-inline void synchBarrierLeave(SynchBarrier *bar) {
+void synchBarrierLeave(SynchBarrier *bar) {
     synchFAA32(&bar->arrive, -1);
     synchFAA32(&bar->leave, -1);
 }
 
-inline void synchBarrierLastLeave(SynchBarrier *bar) {
+void synchBarrierLastLeave(SynchBarrier *bar) {
     synchBarrierLeave(bar);
     while (bar->arrive != 0 && bar->leave != 0) {
         synchResched();

--- a/libconcurrent/primitives/fastrand.c
+++ b/libconcurrent/primitives/fastrand.c
@@ -2,9 +2,9 @@
 #include <limits.h>
 #include <math.h>
 
-static __thread long __fast_random_next = 1;
-static __thread uint32_t __fast_random_next_z = 2;
-static __thread uint32_t __fast_random_next_w = 2;
+static _Thread_local long __fast_random_next = 1;
+static _Thread_local uint32_t __fast_random_next_z = 2;
+static _Thread_local uint32_t __fast_random_next_w = 2;
 
 long synchFastRandom(void) {
     __fast_random_next = __fast_random_next * 1103515245 + 12345;

--- a/libconcurrent/primitives/primitives.c
+++ b/libconcurrent/primitives/primitives.c
@@ -25,7 +25,7 @@ inline bool __CASPTR(void *A, void *B, void *C) {
     uint64_t prev;
     uint64_t *p = (uint64_t *)A;
 
-    asm volatile("lock;"
+    __asm__ volatile("lock;"
                  "cmpxchgq %1,%2" 
                  : "=a"(prev)
                  : "r"((uint64_t)C), "m"(*p), "0"((uint64_t)B) 
@@ -37,7 +37,7 @@ inline bool __CAS64(volatile uint64_t *A, uint64_t B, uint64_t C) {
     uint64_t prev;
     uint64_t *p = (uint64_t *)A;
 
-    asm volatile("lock;"
+    __asm__ volatile("lock;"
                  "cmpxchgq %1,%2"
                  : "=a"(prev)
                  : "r"(C), "m"(*p), "0"(B)
@@ -49,7 +49,7 @@ inline bool __CAS32(uint32_t *A, uint32_t B, uint32_t C) {
     uint32_t prev;
     uint32_t *p = (uint32_t *)A;
 
-    asm volatile("lock;"
+    __asm__ volatile("lock;"
                  "cmpxchgl %1,%2" 
                  : "=a"(prev) 
                  : "r"(C), "m"(*p), "0"(B) 
@@ -60,7 +60,7 @@ inline bool __CAS32(uint32_t *A, uint32_t B, uint32_t C) {
 inline void *__SWAP(void *A, void *B) {
     int64_t *p = (int64_t *)A;
 
-    asm volatile("lock;"
+    __asm__ volatile("lock;"
                  "xchgq %0, %1"
                  : "=r"(B), "=m"(*p)
                  : "0"(B), "m"(*p)
@@ -69,7 +69,7 @@ inline void *__SWAP(void *A, void *B) {
 }
 
 inline int64_t __FAA64(volatile int64_t *A, int64_t B) {
-    asm volatile("lock;"
+    __asm__ volatile("lock;"
                  "xaddq %0, %1"
                  : "=r"(B), "=m"(*A)
                  : "0"(B), "m"(*A)
@@ -78,7 +78,7 @@ inline int64_t __FAA64(volatile int64_t *A, int64_t B) {
 }
 
 inline int32_t __FAA32(volatile int32_t *A, int32_t B) {
-    asm volatile("lock;"
+    __asm__ volatile("lock;"
                  "xaddl %0, %1"
                  : "=r"(B), "=m"(*A)
                  : "0"(B), "m"(*A)
@@ -89,7 +89,7 @@ inline int32_t __FAA32(volatile int32_t *A, int32_t B) {
 inline uint64_t __BitTAS64(volatile uint64_t *A, unsigned char B) {
     int64_t *p = (int64_t *)A;
     int64_t bit = B;
-    asm volatile("lock;" 
+    __asm__ volatile("lock;" 
                  "btsq %0, %1"
                  : "=r"(bit), "=m"(*p)
                  : "0"(bit), "m"(*p)
@@ -101,7 +101,7 @@ inline uint64_t __BitTAS64(volatile uint64_t *A, unsigned char B) {
 inline int synchBitSearchFirst(uint64_t B) {
     uint64_t A;
 
-    asm("bsfq %0, %1;" : "=d"(A) : "d"(B));
+    __asm__("bsfq %0, %1;" : "=d"(A) : "d"(B));
 
     return (int)A;
 }
@@ -122,7 +122,7 @@ inline bool _CAS128(uint64_t *A, uint64_t B0, uint64_t B1, uint64_t C0, uint64_t
 #if defined(__OLD_GCC_X86__) || defined(__amd64__) || defined(__x86_64__)
     uint64_t dummy;
 
-    asm volatile("lock;"
+    __asm__ volatile("lock;"
                  "cmpxchg16b %2; setz %1"
                  : "=d" (dummy), "=a" (res), "+m" (*A)
                  : "b" (C0), "c" (C1), "a" (B0),  "d" (B1));
@@ -199,7 +199,7 @@ inline uint64_t synchGetMachineModel(void) {
 #if defined(__amd64__) || defined(__x86_64__)
     char cpu_model[MAX_VENDOR_STR_SIZE] = {'\0'};
 
-    asm volatile("movl $0, %%eax\n"
+    __asm__ volatile("movl $0, %%eax\n"
                  "cpuid\n"
                  "movl %%ebx, %0\n"
                  "movl %%edx, %1\n"

--- a/libconcurrent/primitives/primitives.c
+++ b/libconcurrent/primitives/primitives.c
@@ -21,7 +21,7 @@ extern __thread int64_t __executed_faa;
 #endif
 
 #ifdef __OLD_GCC_X86__
-inline bool __CASPTR(void *A, void *B, void *C) {
+bool __CASPTR(void *A, void *B, void *C) {
     uint64_t prev;
     uint64_t *p = (uint64_t *)A;
 
@@ -33,7 +33,7 @@ inline bool __CASPTR(void *A, void *B, void *C) {
     return (prev == (uint64_t)B);
 }
 
-inline bool __CAS64(volatile uint64_t *A, uint64_t B, uint64_t C) {
+bool __CAS64(volatile uint64_t *A, uint64_t B, uint64_t C) {
     uint64_t prev;
     uint64_t *p = (uint64_t *)A;
 
@@ -45,7 +45,7 @@ inline bool __CAS64(volatile uint64_t *A, uint64_t B, uint64_t C) {
     return (prev == B);
 }
 
-inline bool __CAS32(uint32_t *A, uint32_t B, uint32_t C) {
+bool __CAS32(uint32_t *A, uint32_t B, uint32_t C) {
     uint32_t prev;
     uint32_t *p = (uint32_t *)A;
 
@@ -57,7 +57,7 @@ inline bool __CAS32(uint32_t *A, uint32_t B, uint32_t C) {
     return (prev == B);
 }
 
-inline void *__SWAP(void *A, void *B) {
+void *__SWAP(void *A, void *B) {
     int64_t *p = (int64_t *)A;
 
     __asm__ volatile("lock;"
@@ -68,7 +68,7 @@ inline void *__SWAP(void *A, void *B) {
     return B;
 }
 
-inline int64_t __FAA64(volatile int64_t *A, int64_t B) {
+int64_t __FAA64(volatile int64_t *A, int64_t B) {
     __asm__ volatile("lock;"
                  "xaddq %0, %1"
                  : "=r"(B), "=m"(*A)
@@ -77,7 +77,7 @@ inline int64_t __FAA64(volatile int64_t *A, int64_t B) {
     return B;
 }
 
-inline int32_t __FAA32(volatile int32_t *A, int32_t B) {
+int32_t __FAA32(volatile int32_t *A, int32_t B) {
     __asm__ volatile("lock;"
                  "xaddl %0, %1"
                  : "=r"(B), "=m"(*A)
@@ -86,7 +86,7 @@ inline int32_t __FAA32(volatile int32_t *A, int32_t B) {
     return B;
 }
 
-inline uint64_t __BitTAS64(volatile uint64_t *A, unsigned char B) {
+uint64_t __BitTAS64(volatile uint64_t *A, unsigned char B) {
     int64_t *p = (int64_t *)A;
     int64_t bit = B;
     __asm__ volatile("lock;" 
@@ -98,7 +98,7 @@ inline uint64_t __BitTAS64(volatile uint64_t *A, unsigned char B) {
     return bit;
 }
 
-inline int synchBitSearchFirst(uint64_t B) {
+int synchBitSearchFirst(uint64_t B) {
     uint64_t A;
 
     __asm__("bsfq %0, %1;" : "=d"(A) : "d"(B));
@@ -106,7 +106,7 @@ inline int synchBitSearchFirst(uint64_t B) {
     return (int)A;
 }
 
-inline uint64_t synchNonZeroBits(uint64_t v) {
+uint64_t synchNonZeroBits(uint64_t v) {
     uint64_t c;
 
     for (c = 0; v; v >>= 1)
@@ -116,7 +116,7 @@ inline uint64_t synchNonZeroBits(uint64_t v) {
 }
 #endif
 
-inline bool _CAS128(uint64_t *A, uint64_t B0, uint64_t B1, uint64_t C0, uint64_t C1) {
+bool _CAS128(uint64_t *A, uint64_t B0, uint64_t B1, uint64_t C0, uint64_t C1) {
     bool res;
 
 #if defined(__OLD_GCC_X86__) || defined(__amd64__) || defined(__x86_64__)
@@ -140,7 +140,7 @@ inline bool _CAS128(uint64_t *A, uint64_t B0, uint64_t B1, uint64_t C0, uint64_t
     return res;
 }
 
-inline void *synchGetMemory(size_t size) {
+void *synchGetMemory(size_t size) {
     void *p;
 
 #ifdef SYNCH_NUMA_SUPPORT
@@ -155,7 +155,7 @@ inline void *synchGetMemory(size_t size) {
         return p;
 }
 
-inline void *synchGetAlignedMemory(size_t align, size_t size) {
+void *synchGetAlignedMemory(size_t align, size_t size) {
     void *p;
 
 #ifdef SYNCH_NUMA_SUPPORT
@@ -175,7 +175,7 @@ inline void *synchGetAlignedMemory(size_t align, size_t size) {
         return p;
 }
 
-inline void synchFreeMemory(void *ptr, size_t size) {
+void synchFreeMemory(void *ptr, size_t size) {
 #ifdef SYNCH_NUMA_SUPPORT
     numa_free(ptr, size);
 #else
@@ -183,7 +183,7 @@ inline void synchFreeMemory(void *ptr, size_t size) {
 #endif
 }
 
-inline int64_t synchGetTimeMillis(void) {
+int64_t synchGetTimeMillis(void) {
     struct timespec tm;
 
     if (clock_gettime(CLOCK_MONOTONIC, &tm) == -1) {
@@ -192,7 +192,7 @@ inline int64_t synchGetTimeMillis(void) {
     } else return tm.tv_sec*1000LL + tm.tv_nsec/1000000LL;
 }
 
-inline uint64_t synchGetMachineModel(void) {
+uint64_t synchGetMachineModel(void) {
     if (__machine_model != UNINITIALIZED_MACHINE_MODEL)
         return __machine_model;
 
@@ -227,7 +227,7 @@ inline uint64_t synchGetMachineModel(void) {
     return __machine_model;
 }
 
-inline bool _CASPTR(void *A, void *B, void *C) {
+bool _CASPTR(void *A, void *B, void *C) {
 #ifdef DEBUG
     int res;
 
@@ -241,7 +241,7 @@ inline bool _CASPTR(void *A, void *B, void *C) {
 #endif
 }
 
-inline bool _CAS64(uint64_t *A, uint64_t B, uint64_t C) {
+bool _CAS64(uint64_t *A, uint64_t B, uint64_t C) {
 #ifdef DEBUG
     int res;
 
@@ -255,7 +255,7 @@ inline bool _CAS64(uint64_t *A, uint64_t B, uint64_t C) {
 #endif
 }
 
-inline bool _CAS32(uint32_t *A, uint32_t B, uint32_t C) {
+bool _CAS32(uint32_t *A, uint32_t B, uint32_t C) {
 #ifdef DEBUG
     int res;
 
@@ -269,7 +269,7 @@ inline bool _CAS32(uint32_t *A, uint32_t B, uint32_t C) {
 #endif
 }
 
-inline void *_SWAP(void *A, void *B) {
+void *_SWAP(void *A, void *B) {
 #if defined(SYNCH_EMULATE_SWAP)
 #    warning synchSWAP instructions are simulated!
     void *old_val;
@@ -294,7 +294,7 @@ inline void *_SWAP(void *A, void *B) {
 #endif
 }
 
-inline int32_t _FAA32(volatile int32_t *A, int32_t B) {
+int32_t _FAA32(volatile int32_t *A, int32_t B) {
 #if defined(SYNCH_EMULATE_FAA)
 #    warning Fetch&Add instructions are simulated!
 
@@ -320,7 +320,7 @@ inline int32_t _FAA32(volatile int32_t *A, int32_t B) {
 #endif
 }
 
-inline int64_t _FAA64(volatile int64_t *A, int64_t B) {
+int64_t _FAA64(volatile int64_t *A, int64_t B) {
 #if defined(SYNCH_EMULATE_FAA)
 #    warning Fetch&Add instructions are simulated!
 
@@ -346,6 +346,6 @@ inline int64_t _FAA64(volatile int64_t *A, int64_t B) {
 #endif
 }
 
-inline uint64_t _BitTAS64(volatile uint64_t *A, unsigned char B) {
+uint64_t _BitTAS64(volatile uint64_t *A, unsigned char B) {
     return __BitTAS64(A, B);
 }

--- a/libconcurrent/primitives/primitives.c
+++ b/libconcurrent/primitives/primitives.c
@@ -23,7 +23,7 @@ extern _Thread_local int64_t __executed_faa;
 bool _CAS128(uint64_t *A, uint64_t B0, uint64_t B1, uint64_t C0, uint64_t C1) {
     bool res;
 
-#if defined(__OLD_GCC_X86__) || defined(__amd64__) || defined(__x86_64__)
+#if defined(__amd64__) || defined(__x86_64__)
     uint64_t dummy;
 
     __asm__ volatile("lock;"

--- a/libconcurrent/primitives/primitives.c
+++ b/libconcurrent/primitives/primitives.c
@@ -11,109 +11,13 @@
 
 #define MAX_VENDOR_STR_SIZE 64
 
-static __thread uint32_t __machine_model = UNINITIALIZED_MACHINE_MODEL;
+static _Thread_local uint32_t __machine_model = UNINITIALIZED_MACHINE_MODEL;
 
 #ifdef DEBUG
-extern __thread int64_t __failed_cas;
-extern __thread int64_t __executed_cas;
-extern __thread int64_t __executed_swap;
-extern __thread int64_t __executed_faa;
-#endif
-
-#ifdef __OLD_GCC_X86__
-bool __CASPTR(void *A, void *B, void *C) {
-    uint64_t prev;
-    uint64_t *p = (uint64_t *)A;
-
-    __asm__ volatile("lock;"
-                 "cmpxchgq %1,%2" 
-                 : "=a"(prev)
-                 : "r"((uint64_t)C), "m"(*p), "0"((uint64_t)B) 
-                 : "memory");
-    return (prev == (uint64_t)B);
-}
-
-bool __CAS64(volatile uint64_t *A, uint64_t B, uint64_t C) {
-    uint64_t prev;
-    uint64_t *p = (uint64_t *)A;
-
-    __asm__ volatile("lock;"
-                 "cmpxchgq %1,%2"
-                 : "=a"(prev)
-                 : "r"(C), "m"(*p), "0"(B)
-                 : "memory");
-    return (prev == B);
-}
-
-bool __CAS32(uint32_t *A, uint32_t B, uint32_t C) {
-    uint32_t prev;
-    uint32_t *p = (uint32_t *)A;
-
-    __asm__ volatile("lock;"
-                 "cmpxchgl %1,%2" 
-                 : "=a"(prev) 
-                 : "r"(C), "m"(*p), "0"(B) 
-                 : "memory");
-    return (prev == B);
-}
-
-void *__SWAP(void *A, void *B) {
-    int64_t *p = (int64_t *)A;
-
-    __asm__ volatile("lock;"
-                 "xchgq %0, %1"
-                 : "=r"(B), "=m"(*p)
-                 : "0"(B), "m"(*p)
-                 : "memory");
-    return B;
-}
-
-int64_t __FAA64(volatile int64_t *A, int64_t B) {
-    __asm__ volatile("lock;"
-                 "xaddq %0, %1"
-                 : "=r"(B), "=m"(*A)
-                 : "0"(B), "m"(*A)
-                 : "memory");
-    return B;
-}
-
-int32_t __FAA32(volatile int32_t *A, int32_t B) {
-    __asm__ volatile("lock;"
-                 "xaddl %0, %1"
-                 : "=r"(B), "=m"(*A)
-                 : "0"(B), "m"(*A)
-                 : "memory");
-    return B;
-}
-
-uint64_t __BitTAS64(volatile uint64_t *A, unsigned char B) {
-    int64_t *p = (int64_t *)A;
-    int64_t bit = B;
-    __asm__ volatile("lock;" 
-                 "btsq %0, %1"
-                 : "=r"(bit), "=m"(*p)
-                 : "0"(bit), "m"(*p)
-                 : "memory");
-
-    return bit;
-}
-
-int synchBitSearchFirst(uint64_t B) {
-    uint64_t A;
-
-    __asm__("bsfq %0, %1;" : "=d"(A) : "d"(B));
-
-    return (int)A;
-}
-
-uint64_t synchNonZeroBits(uint64_t v) {
-    uint64_t c;
-
-    for (c = 0; v; v >>= 1)
-        c += v & 1;
-
-    return c;
-}
+extern _Thread_local int64_t __failed_cas;
+extern _Thread_local int64_t __executed_cas;
+extern _Thread_local int64_t __executed_swap;
+extern _Thread_local int64_t __executed_faa;
 #endif
 
 bool _CAS128(uint64_t *A, uint64_t B0, uint64_t B1, uint64_t C0, uint64_t C1) {

--- a/libconcurrent/primitives/stats.c
+++ b/libconcurrent/primitives/stats.c
@@ -7,10 +7,10 @@
 #    include <types.h>
 #    include <system.h>
 
-__thread int64_t __failed_cas CACHE_ALIGN = 0;
-__thread int64_t __executed_cas CACHE_ALIGN = 0;
-__thread int64_t __executed_swap CACHE_ALIGN = 0;
-__thread int64_t __executed_faa CACHE_ALIGN = 0;
+_Thread_local int64_t __failed_cas CACHE_ALIGN = 0;
+_Thread_local int64_t __executed_cas CACHE_ALIGN = 0;
+_Thread_local int64_t __executed_swap CACHE_ALIGN = 0;
+_Thread_local int64_t __executed_faa CACHE_ALIGN = 0;
 
 volatile int64_t __total_failed_cas = 0;
 volatile int64_t __total_executed_cas = 0;

--- a/libconcurrent/primitives/threadtools.c
+++ b/libconcurrent/primitives/threadtools.c
@@ -14,8 +14,8 @@
 #    include <numa.h>
 #endif
 
-inline static void *uthreadWrapper(void *arg);
-inline static void *kthreadWrapper(void *arg);
+static void *uthreadWrapper(void *arg);
+static void *kthreadWrapper(void *arg);
 
 static __thread pthread_t *__threads;
 static __thread int32_t __thread_id = 0;
@@ -49,21 +49,21 @@ void setThreadId(int32_t id) {
     __thread_id = id;
 }
 
-inline int32_t synchGetPreferredCore(void) {
+int32_t synchGetPreferredCore(void) {
     return __preferred_core;
 }
 
-inline int32_t synchGetPreferredNumaNode(void) {
+int32_t synchGetPreferredNumaNode(void) {
     return __preferred_numa_node;
 }
 
-inline uint32_t synchGetNCores(void) {
+uint32_t synchGetNCores(void) {
     if (__ncores == 0)
         __ncores = sysconf(_SC_NPROCESSORS_ONLN);
     return __ncores;
 }
 
-inline static void *kthreadWrapper(void *arg) {
+static void *kthreadWrapper(void *arg) {
     int cpu_id;
     long pid = (long)arg;
 
@@ -77,7 +77,7 @@ inline static void *kthreadWrapper(void *arg) {
     return NULL;
 }
 
-inline uint32_t synchPreferredCoreOfThread(uint32_t pid) {
+uint32_t synchPreferredCoreOfThread(uint32_t pid) {
     uint32_t preferred_core = 0;
 
     if (__schedule_policy == SYNCH_THREAD_PLACEMENT_FLAT) {
@@ -125,7 +125,7 @@ inline uint32_t synchPreferredCoreOfThread(uint32_t pid) {
     return preferred_core;
 }
 
-inline uint32_t synchPreferredNumaNodeOfThread(uint32_t pid) {
+uint32_t synchPreferredNumaNodeOfThread(uint32_t pid) {
     uint32_t preferred_node = 0;
 
 #ifdef SYNCH_NUMA_SUPPORT
@@ -171,7 +171,7 @@ int synchThreadPin(int32_t cpu_id) {
     return ret;
 }
 
-inline static void *uthreadWrapper(void *arg) {
+static void *uthreadWrapper(void *arg) {
     int i, kernel_id;
     long pid = (long)arg;
 
@@ -246,15 +246,15 @@ void synchJoinThreadsN(uint32_t nthreads) {
     synchFreeMemory(__threads, nthreads * sizeof(pthread_t));
 }
 
-inline int32_t synchGetThreadId(void) {
+int32_t synchGetThreadId(void) {
     return __thread_id + synchCurrentFiberIndex();
 }
 
-inline int32_t synchGetPosixThreadId(void) {
+int32_t synchGetPosixThreadId(void) {
     return __thread_id;
 }
 
-inline void synchResched(void) {
+void synchResched(void) {
     if (__noop_resched) {
         synchPause();
     } else if (__uthread_sched) {
@@ -264,6 +264,6 @@ inline void synchResched(void) {
     }
 }
 
-inline bool synchIsSystemOversubscribed(void) {
+bool synchIsSystemOversubscribed(void) {
     return __system_oversubscription;
 }

--- a/libconcurrent/primitives/uthreads.c
+++ b/libconcurrent/primitives/uthreads.c
@@ -15,8 +15,8 @@ typedef struct FiberData {
     long arg;
 } FiberData;
 
-inline static void switch_to_fiber(Fiber *prev, Fiber *cur);
-inline static void fiber_start_func(FiberData *context);
+static void switch_to_fiber(Fiber *prev, Fiber *cur);
+static void fiber_start_func(FiberData *context);
 
 static volatile __thread int N_FIBERS = 1;
 static __thread Fiber *FIBER_LIST = NULL;
@@ -36,7 +36,7 @@ void synchInitFibers(int max) {
         FIBER_LIST[i].active = false;
 }
 
-inline static void switch_to_fiber(Fiber *prev, Fiber *cur) {
+static void switch_to_fiber(Fiber *prev, Fiber *cur) {
     if (_setjmp(prev->jmp) == 0) {
         _longjmp(cur->jmp, 1);
     }

--- a/libconcurrent/primitives/uthreads.c
+++ b/libconcurrent/primitives/uthreads.c
@@ -18,11 +18,11 @@ typedef struct FiberData {
 static void switch_to_fiber(Fiber *prev, Fiber *cur);
 static void fiber_start_func(FiberData *context);
 
-static volatile __thread int N_FIBERS = 1;
-static __thread Fiber *FIBER_LIST = NULL;
-static __thread Fiber *FIBER_RECYCLE = NULL;
-static __thread int MAX_FIBERS = 1;
-static __thread int currentFiber = 0;
+static volatile _Thread_local int N_FIBERS = 1;
+static _Thread_local Fiber *FIBER_LIST = NULL;
+static _Thread_local Fiber *FIBER_RECYCLE = NULL;
+static _Thread_local int MAX_FIBERS = 1;
+static _Thread_local int currentFiber = 0;
 
 void synchInitFibers(int max) {
     int i;

--- a/libconcurrent/serial/serialheap.c
+++ b/libconcurrent/serial/serialheap.c
@@ -1,13 +1,13 @@
 #include <serialheap.h>
 
-inline static SynchHeapElement serialHeapDeleteMinMax(SerialHeapStruct *heap_state);
-inline static SynchHeapElement serialHeapInsert(SerialHeapStruct *heap_state, SynchHeapElement el);
-inline static SynchHeapElement serialHeapGetMinMax(SerialHeapStruct *heap_state);
-inline static void serialHeapCorrectDown(SerialHeapStruct *heap_state, uint32_t level, uint32_t pos);
-inline static void serialHeapCorrectUp(SerialHeapStruct *heap_state);
-inline static bool serialHeapGrow(SerialHeapStruct *heap_state);
+static SynchHeapElement serialHeapDeleteMinMax(SerialHeapStruct *heap_state);
+static SynchHeapElement serialHeapInsert(SerialHeapStruct *heap_state, SynchHeapElement el);
+static SynchHeapElement serialHeapGetMinMax(SerialHeapStruct *heap_state);
+static void serialHeapCorrectDown(SerialHeapStruct *heap_state, uint32_t level, uint32_t pos);
+static void serialHeapCorrectUp(SerialHeapStruct *heap_state);
+static bool serialHeapGrow(SerialHeapStruct *heap_state);
 
-inline void serialHeapInit(SerialHeapStruct *heap_state, uint32_t type) {
+void serialHeapInit(SerialHeapStruct *heap_state, uint32_t type) {
     uint64_t i;
 
     heap_state->items = 0;
@@ -23,7 +23,7 @@ inline void serialHeapInit(SerialHeapStruct *heap_state, uint32_t type) {
         heap_state->heap_arrays[i] = &heap_state->bulk[(1ULL << i) - 1];
 }
 
-inline static void serialHeapCorrectDown(SerialHeapStruct *heap_state, uint32_t level, uint32_t pos) {
+static void serialHeapCorrectDown(SerialHeapStruct *heap_state, uint32_t level, uint32_t pos) {
     while (level > 0) {
         uint32_t pos_div_2 = pos / 2;
         if (heap_state->type == SYNCH_HEAP_TYPE_MIN) {
@@ -48,7 +48,7 @@ inline static void serialHeapCorrectDown(SerialHeapStruct *heap_state, uint32_t 
     }
 }
 
-inline static void serialHeapCorrectUp(SerialHeapStruct *heap_state) {
+static void serialHeapCorrectUp(SerialHeapStruct *heap_state) {
     uint32_t level = 0;
     uint32_t pos = 0;
 
@@ -93,7 +93,7 @@ inline static void serialHeapCorrectUp(SerialHeapStruct *heap_state) {
     }
 }
 
-inline static SynchHeapElement serialHeapDeleteMinMax(SerialHeapStruct *heap_state) {
+static SynchHeapElement serialHeapDeleteMinMax(SerialHeapStruct *heap_state) {
     SynchHeapElement ret = serialHeapGetMinMax(heap_state);
 
     if (ret != SYNCH_HEAP_EMPTY) {
@@ -122,7 +122,7 @@ inline static SynchHeapElement serialHeapDeleteMinMax(SerialHeapStruct *heap_sta
     return ret;
 }
 
-inline static bool serialHeapGrow(SerialHeapStruct *heap_state) {
+static bool serialHeapGrow(SerialHeapStruct *heap_state) {
     SynchHeapElement *expanded_bulk = NULL;
     uint64_t i;
 
@@ -142,7 +142,7 @@ inline static bool serialHeapGrow(SerialHeapStruct *heap_state) {
     return true;
 }
 
-inline static SynchHeapElement serialHeapInsert(SerialHeapStruct *heap_state, SynchHeapElement el) {
+static SynchHeapElement serialHeapInsert(SerialHeapStruct *heap_state, SynchHeapElement el) {
     // Check if there is enough space inside the last level
     if (heap_state->last_used_level_pos < heap_state->last_used_level_size) {
         heap_state->heap_arrays[heap_state->last_used_level][heap_state->last_used_level_pos] = el;
@@ -176,13 +176,13 @@ inline static SynchHeapElement serialHeapInsert(SerialHeapStruct *heap_state, Sy
     }
 }
 
-inline static SynchHeapElement serialHeapGetMinMax(SerialHeapStruct *heap_state) {
+static SynchHeapElement serialHeapGetMinMax(SerialHeapStruct *heap_state) {
     if (heap_state->last_used_level != 0 && heap_state->last_used_level_pos != 0) return heap_state->heap_arrays[0][0];
     return SYNCH_HEAP_EMPTY;
 }
 
 #ifdef DEBUG
-inline static void serialDisplay(SerialHeapStruct *heap_state) {
+static void serialDisplay(SerialHeapStruct *heap_state) {
     int i, j;
 
     for (i = 0; i < heap_state->last_used_level; i++) {
@@ -199,7 +199,7 @@ inline static void serialDisplay(SerialHeapStruct *heap_state) {
 }
 #endif
 
-inline bool serialHeapClearAndValidation(SerialHeapStruct *heap_state) {
+bool serialHeapClearAndValidation(SerialHeapStruct *heap_state) {
     SynchHeapElement elmnt, prev;
     uint64_t i = 0;
 #ifdef DEBUG
@@ -217,7 +217,7 @@ inline bool serialHeapClearAndValidation(SerialHeapStruct *heap_state) {
     return true;
 }
 
-inline RetVal serialHeapApplyOperation(void *state, ArgVal arg, int pid) {
+RetVal serialHeapApplyOperation(void *state, ArgVal arg, int pid) {
     SynchHeapElement ret = SYNCH_HEAP_EMPTY;
     uint64_t op = arg & SYNCH_HEAP_OP_MASK;
     uint64_t val = arg & SYNCH_HEAP_VAL_MASK;


### PR DESCRIPTION
Switched C standard from `gnu89` to `C11` for improved compatibility, modern features, and better code maintainability.